### PR TITLE
WFS / do not throw if asking for an unknown WFS output format

### DIFF
--- a/src/wfs/endpoint.js
+++ b/src/wfs/endpoint.js
@@ -345,7 +345,8 @@ export default class WfsEndpoint {
       outputFormat &&
       internalFeatureType.outputFormats.indexOf(outputFormat) === -1
     ) {
-      throw new Error(
+      // do not prevent using this output format, because it still might work! but give a warning at least
+      console.warn(
         `The following output format type was not found in the feature type ${internalFeatureType.name}: ${outputFormat}`
       );
     }

--- a/src/wfs/endpoint.spec.js
+++ b/src/wfs/endpoint.spec.js
@@ -15,6 +15,10 @@ describe('WfsEndpoint', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(console, 'warn');
+  });
+
+  beforeEach(() => {
     window.fetchResponseFactory = (url) => {
       if (url.indexOf('GetCapabilities') > -1) return capabilities200;
       if (url.indexOf('GetFeature') > -1) {
@@ -446,13 +450,14 @@ describe('WfsEndpoint', () => {
         'feature type'
       );
     });
-    it('throws an error if the required output format is not supported by the feature type', () => {
-      expect(() =>
-        endpoint.getFeatureUrl('hierarchisation_l', {
-          maxFeatures: 200,
-          outputFormat: 'application/invalid+mime+type',
-        })
-      ).toThrow('output format');
+    it('logs a warning if the required output format is not supported by the feature type', () => {
+      endpoint.getFeatureUrl('hierarchisation_l', {
+        maxFeatures: 200,
+        outputFormat: 'application/invalid+mime+type',
+      });
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('output format')
+      );
     });
     it('throws an error if the the feature type does not support geojson', () => {
       expect(() =>


### PR DESCRIPTION
There are several examples of OGC servers being able to answer on application/json for example while this format not being listed in the capabilities.