### PR TITLE
Add basic OGC-API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+coverage
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
-fixtures
+fixtures/**/*.xml
 dist
 app/dist
 node_modules

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ The following standards are partially implemented:
 
 - WMS - _Web Map Service_
 - WFS - _Web Feature Service_
+- OGC API
 
-Why no WMTS support? Because [openlayers](https://www.github.com/openlayers/openlayers) has a incredibly thorough and well-tested WMTS capabilities parser and you should just use it.
+Why no WMTS support? Because [openlayers](https://www.github.com/openlayers/openlayers) has an incredibly thorough and well-tested WMTS capabilities parser and you should just use it.
 Reimplementing it in **ogc-client** currently does not bring any significant value.
 
 ## Why use it?

--- a/app/src/Demo.vue
+++ b/app/src/Demo.vue
@@ -13,6 +13,13 @@
       feature types from it.
     </p>
     <WfsEndpoint></WfsEndpoint>
+
+    <h2 class="my-4">OGC API</h2>
+    <p>
+      Enter an OGC API endpoint URL below to get some information and a list of
+      collections from it.
+    </p>
+    <OgcApiEndpoint></OgcApiEndpoint>
   </div>
 </template>
 
@@ -21,9 +28,10 @@
 <script>
 import WmsEndpoint from './components/wms/WmsEndpoint';
 import WfsEndpoint from './components/wfs/WfsEndpoint';
+import OgcApiEndpoint from './components/ogc-api/OgcApiEndpoint.vue';
 
 export default {
   name: 'App',
-  components: { WfsEndpoint, WmsEndpoint },
+  components: { OgcApiEndpoint, WfsEndpoint, WmsEndpoint },
 };
 </script>

--- a/app/src/components/ogc-api/OgcApiEndpoint.vue
+++ b/app/src/components/ogc-api/OgcApiEndpoint.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <div class="d-flex flex-row">
+      <input
+        class="form-control me-3"
+        placeholder="Enter an OGC API endpoint URL here"
+        v-model="url"
+      />
+      <div class="spacer-s"></div>
+      <button type="button" class="btn btn-primary" @click="createEndpoint()">
+        Analyze
+      </button>
+    </div>
+    <Async v-if="endpointSummary" :promise="endpointSummary">
+      <template v-slot:then="{ result }">
+        <InfoList :info="result.info"></InfoList>
+        <ItemsTree :items="result.collections" style="min-height: 200px">
+          <template v-slot="{ item }">
+            <span>{{ item }}</span>
+          </template>
+        </ItemsTree>
+      </template>
+    </Async>
+  </div>
+</template>
+
+<script>
+import InfoList from '../presentation/InfoList';
+import ItemsTree from '../presentation/ItemsTree';
+import Async from '../presentation/Async';
+import OgcApiEndpoint from '../../../../dist/ogc-api/endpoint';
+
+export default {
+  name: 'OgcApiEndpoint',
+  components: { Async, ItemsTree, InfoList },
+  data: () => ({
+    endpoint: null,
+    endpointSummary: null,
+    endpointCollections: null,
+    url: 'https://demo.ldproxy.net/zoomstack',
+  }),
+  computed: {
+    loaded() {
+      return this.endpoint && this.loading === false && this.error === null;
+    },
+  },
+  methods: {
+    createEndpoint() {
+      this.endpoint = new OgcApiEndpoint(this.url);
+      this.endpointSummary = Promise.all([
+        this.endpoint.info,
+        this.endpoint.hasTiles,
+        this.endpoint.hasStyles,
+        this.endpoint.hasRecords,
+        this.endpoint.hasFeatures,
+        this.endpoint.allCollections,
+      ]).then(
+        ([
+          info,
+          hasTiles,
+          hasStyles,
+          hasRecords,
+          hasFeatures,
+          collections,
+        ]) => ({
+          info: {
+            ...info,
+            hasTiles,
+            hasStyles,
+            hasRecords,
+            hasFeatures,
+          },
+          collections,
+        })
+      );
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/app/src/components/presentation/Async.vue
+++ b/app/src/components/presentation/Async.vue
@@ -1,0 +1,64 @@
+<template>
+  <!-- inspired by https://github.com/byteboomers/vue-prom -->
+  <div v-if="pending">
+    <slot name="pending">
+      <span>Loading...</span>
+    </slot>
+  </div>
+  <div v-else-if="rejected">
+    <slot name="catch" :error="rejected">
+      <span class="error">Error: {{ rejected }}</span>
+    </slot>
+  </div>
+  <div v-else>
+    <slot name="then" :result="resolved">
+      <span>Loaded: {{ resolved }}</span>
+    </slot>
+  </div>
+</template>
+
+<style scoped>
+.error {
+  color: darkred;
+}
+</style>
+
+<script>
+export default {
+  name: 'Async',
+  props: {
+    promise: Promise,
+  },
+  data: () => ({
+    pending: true,
+    resolved: null,
+    rejected: null,
+  }),
+  watch: {
+    promise: {
+      immediate: true,
+      handler(value) {
+        if (value instanceof Promise) {
+          this.pending = true;
+          value.then(
+            (resolved) => {
+              this.resolved = resolved;
+              this.rejected = null;
+              this.pending = false;
+            },
+            (rejected) => {
+              this.rejected = rejected;
+              this.resolved = null;
+              this.pending = false;
+            }
+          );
+        } else {
+          this.resolved = value;
+          this.rejected = null;
+          this.pending = false;
+        }
+      },
+    },
+  },
+};
+</script>

--- a/app/src/components/presentation/TreeItem.vue
+++ b/app/src/components/presentation/TreeItem.vue
@@ -20,13 +20,10 @@
 <script>
 export default {
   name: 'TreeItem',
-  props: {
-    /** @type {{new (): TreeItem}} */
-    item: Object,
-  },
+  props: ['item'],
   computed: {
     hasChildren() {
-      return 'children' in this.item;
+      return this.item instanceof Object && 'children' in this.item;
     },
     children() {
       return this.item.children;

--- a/fixtures/ogc-api/sample-data.json
+++ b/fixtures/ogc-api/sample-data.json
@@ -1,0 +1,95 @@
+{
+  "title": "OS Open Zoomstack",
+  "description": "OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data?f=html"
+    },
+    {
+      "rel": "conformance",
+      "title": "OGC API conformance classes implemented by this server",
+      "href": "https://my.server.org/sample-data/conformance"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/conformance",
+      "title": "OGC API conformance classes implemented by this server",
+      "href": "https://my.server.org/sample-data/conformance"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/styles",
+      "title": "Styles to render the data in maps",
+      "href": "https://my.server.org/sample-data/styles"
+    },
+    {
+      "rel": "ldp-map",
+      "title": "Access a web map with the data",
+      "href": "https://my.server.org/sample-data/styles/Road?f=html"
+    },
+    {
+      "rel": "resources",
+      "title": "Resources for rendering the data in maps",
+      "href": "https://my.server.org/sample-data/resources"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector",
+      "title": "Access the data as tiles",
+      "href": "https://my.server.org/sample-data/tiles"
+    },
+    {
+      "rel": "service-doc",
+      "type": "text/html",
+      "title": "Documentation of the API",
+      "href": "https://my.server.org/sample-data/api?f=html"
+    },
+    {
+      "rel": "service-desc",
+      "type": "application/vnd.oai.openapi+json;version=3.0",
+      "title": "Definition of the API in OpenAPI 3.0",
+      "href": "https://my.server.org/sample-data/api?f=json"
+    },
+    {
+      "rel": "service-desc",
+      "type": "application/vnd.oai.openapi;version=3.0",
+      "title": "Definition of the API in OpenAPI 3.0",
+      "href": "https://my.server.org/sample-data/api?f=yaml"
+    },
+    {
+      "rel": "data",
+      "title": "Access the data",
+      "href": "https://my.server.org/sample-data/collections"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/data",
+      "title": "Access the data",
+      "href": "https://my.server.org/sample-data/collections"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+      "title": "List of tile matrix sets implemented by this API",
+      "href": "https://my.server.org/sample-data/tileMatrixSets"
+    }
+  ],
+  "attribution": "Contains OS data © Crown copyright and database right 2021.",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -9.23056668252574,
+          49.81680248396912,
+          2.69547862504583,
+          60.78388658611872
+        ]
+      ],
+      "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+    }
+  }
+}

--- a/fixtures/ogc-api/sample-data/collections.json
+++ b/fixtures/ogc-api/sample-data/collections.json
@@ -1,0 +1,1365 @@
+{
+  "title": "OS Open Zoomstack",
+  "description": "OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data/collections?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/collections?f=html"
+    },
+    {
+      "rel": "alternate",
+      "type": "application/xml",
+      "title": "This document as XML",
+      "href": "https://my.server.org/sample-data/collections?f=xml"
+    },
+    {
+      "rel": "license",
+      "title": "Open Government Licence (OGL)",
+      "href": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    },
+    {
+      "rel": "enclosure",
+      "type": "application/geopackage+sqlite3",
+      "title": "OS Open Zoomstack as a GeoPackage",
+      "href": "https://api.os.uk/downloads/v1/products/OpenZoomstack/downloads?area=GB&format=GeoPackage"
+    }
+  ],
+  "crs": [
+    "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "http://www.opengis.net/def/crs/EPSG/0/27700",
+    "http://www.opengis.net/def/crs/EPSG/0/4258",
+    "http://www.opengis.net/def/crs/EPSG/0/4326",
+    "http://www.opengis.net/def/crs/EPSG/0/3857"
+  ],
+  "collections": [
+    {
+      "title": "Airports",
+      "description": "A centre point for all major airports including a name.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Airports' feature collection",
+          "href": "https://my.server.org/sample-data/collections/airports"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Airports' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/airports/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Airports' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/airports/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Airports' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/airports/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Airports' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/airports/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Airports' as HTML",
+          "href": "https://my.server.org/sample-data/collections/airports/items?f=html"
+        }
+      ],
+      "id": "airports",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -7.942759150065165,
+              49.901607895996534,
+              1.9957427933628138,
+              60.133709755754
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 46
+    },
+    {
+      "title": "Boundaries",
+      "description": "National boundary lines between England - Scotland and England - Wales.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Boundaries' feature collection",
+          "href": "https://my.server.org/sample-data/collections/boundaries"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Boundaries' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/boundaries/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Boundaries' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/boundaries/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Boundaries' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/boundaries/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Boundaries' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/boundaries/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Boundaries' as HTML",
+          "href": "https://my.server.org/sample-data/collections/boundaries/items?f=html"
+        }
+      ],
+      "id": "boundaries",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -3.353443758684184,
+              51.56539937427431,
+              -2.030006856546504,
+              55.81167771035611
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 32
+    },
+    {
+      "title": "Contours",
+      "description": "These contours lines have a 10-metre interval with an index every 50 metres. Each contour contains a value.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Contours' feature collection",
+          "href": "https://my.server.org/sample-data/collections/contours"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Contours' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/contours/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Contours' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/contours/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Contours' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/contours/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Contours' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/contours/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Contours' as HTML",
+          "href": "https://my.server.org/sample-data/collections/contours/items?f=html"
+        }
+      ],
+      "id": "contours",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.229436317495699,
+              49.82026221571111,
+              2.6868283140378657,
+              60.77919884922387
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 952689
+    },
+    {
+      "title": "District Buildings",
+      "description": "Generalised building footprints at district resolution.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'District Buildings' feature collection",
+          "href": "https://my.server.org/sample-data/collections/district_buildings"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'District Buildings' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/district_buildings/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'District Buildings' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/district_buildings/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'District Buildings' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/district_buildings/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'District Buildings' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/district_buildings/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'District Buildings' as HTML",
+          "href": "https://my.server.org/sample-data/collections/district_buildings/items?f=html"
+        }
+      ],
+      "id": "district_buildings",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.161386312800703,
+              49.83051579969082,
+              2.6926347822219707,
+              60.77807759733313
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 2756155
+    },
+    {
+      "title": "ETL",
+      "description": "Electricity Transmission Lines.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'ETL' feature collection",
+          "href": "https://my.server.org/sample-data/collections/etl"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'ETL' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/etl/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'ETL' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/etl/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'ETL' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/etl/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'ETL' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/etl/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'ETL' as HTML",
+          "href": "https://my.server.org/sample-data/collections/etl/items?f=html"
+        }
+      ],
+      "id": "etl",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -6.289748340048653,
+              50.14037477109227,
+              2.33600775696539,
+              58.515541995093926
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 3456
+    },
+    {
+      "title": "Foreshore",
+      "description": "These polygons depict the part of the shore or beach which lies between the Mean Low Water Mark and Mean High Water Mark.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Foreshore' feature collection",
+          "href": "https://my.server.org/sample-data/collections/foreshore"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Foreshore' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/foreshore/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Foreshore' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/foreshore/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Foreshore' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/foreshore/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Foreshore' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/foreshore/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Foreshore' as HTML",
+          "href": "https://my.server.org/sample-data/collections/foreshore/items?f=html"
+        }
+      ],
+      "id": "foreshore",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.229007463313069,
+              49.81685890446522,
+              2.69547862504583,
+              60.783438341201155
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 36931
+    },
+    {
+      "title": "Greenspace",
+      "description": "Polygon features representing the extent of places such as parks and sports facilities that are likely to be accessible to the public.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Greenspace' feature collection",
+          "href": "https://my.server.org/sample-data/collections/greenspace"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Greenspace' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/greenspace/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Greenspace' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/greenspace/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Greenspace' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/greenspace/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Greenspace' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/greenspace/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Greenspace' as HTML",
+          "href": "https://my.server.org/sample-data/collections/greenspace/items?f=html"
+        }
+      ],
+      "id": "greenspace",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.140209405918318,
+              49.847346158649266,
+              2.6798173070292117,
+              60.72844339242528
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 163772
+    },
+    {
+      "title": "Land",
+      "description": "This layer depicts the shape of Great Britain.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Land' feature collection",
+          "href": "https://my.server.org/sample-data/collections/land"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Land' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/land/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Land' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/land/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Land' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/land/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Land' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/land/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Land' as HTML",
+          "href": "https://my.server.org/sample-data/collections/land/items?f=html"
+        }
+      ],
+      "id": "land",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.230549516889134,
+              49.81687027180851,
+              2.6954553633653067,
+              60.78336234918871
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 47845
+    },
+    {
+      "title": "Local Buildings",
+      "description": "Generalised building footprints at local resolution. The buildings have a unique identifier which can be used to style features distinctly. The identifier will not be persistent between product versions and therefore there will be no change history information for a feature.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Local Buildings' feature collection",
+          "href": "https://my.server.org/sample-data/collections/local_buildings"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Local Buildings' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/local_buildings/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Local Buildings' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/local_buildings/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Local Buildings' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/local_buildings/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Local Buildings' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/local_buildings/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Local Buildings' as HTML",
+          "href": "https://my.server.org/sample-data/collections/local_buildings/items?f=html"
+        }
+      ],
+      "id": "local_buildings",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.161552750416005,
+              49.84423409871862,
+              2.693061112022058,
+              60.77806491151261
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 14767492
+    },
+    {
+      "title": "Names",
+      "description": "Use this point layer to render contextual labels on your map.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Names' feature collection",
+          "href": "https://my.server.org/sample-data/collections/names"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Names' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/names/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Names' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/names/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Names' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/names/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Names' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/names/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Names' as HTML",
+          "href": "https://my.server.org/sample-data/collections/names/items?f=html"
+        }
+      ],
+      "id": "names",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.223028104021813,
+              49.8211736840672,
+              2.6872590240033913,
+              60.77819537105956
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 663624
+    },
+    {
+      "title": "National Parks",
+      "description": "Theses polygons depict the extent of the 15 National Parks in Great Britain.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'National Parks' feature collection",
+          "href": "https://my.server.org/sample-data/collections/national_parks"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'National Parks' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/national_parks/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'National Parks' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/national_parks/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'National Parks' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/national_parks/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'National Parks' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/national_parks/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'National Parks' as HTML",
+          "href": "https://my.server.org/sample-data/collections/national_parks/items?f=html"
+        }
+      ],
+      "id": "national_parks",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -6.000951880798203,
+              50.350225515433486,
+              2.197829108619243,
+              57.35677547861099
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 39
+    },
+    {
+      "title": "Rail",
+      "description": "Lines representing the railway network. They are broken where they pass under bridges, buildings or other obstructing detail.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Rail' feature collection",
+          "href": "https://my.server.org/sample-data/collections/rail"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Rail' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/rail/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Rail' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/rail/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Rail' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/rail/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Rail' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/rail/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Rail' as HTML",
+          "href": "https://my.server.org/sample-data/collections/rail/items?f=html"
+        }
+      ],
+      "id": "rail",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -6.57793449730909,
+              50.11274051097212,
+              2.616645763341211,
+              60.35171925328691
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 105582
+    },
+    {
+      "title": "Railway Stations",
+      "description": "This layer contains a point for all stations and includes a name.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Railway Stations' feature collection",
+          "href": "https://my.server.org/sample-data/collections/railway_stations"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Railway Stations' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/railway_stations/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Railway Stations' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/railway_stations/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Railway Stations' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/railway_stations/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Railway Stations' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/railway_stations/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Railway Stations' as HTML",
+          "href": "https://my.server.org/sample-data/collections/railway_stations/items?f=html"
+        }
+      ],
+      "id": "railway_stations",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -6.336940205377114,
+              50.11281330079447,
+              2.373901529064454,
+              58.525818197436486
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 3473
+    },
+    {
+      "title": "Local Roads",
+      "description": "Lines representing the road network. A road is defined as a metalled way for vehicles.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Local Roads' feature collection",
+          "href": "https://my.server.org/sample-data/collections/roads_local"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Local Roads' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/roads_local/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Local Roads' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/roads_local/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Local Roads' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/roads_local/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Local Roads' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/roads_local/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Local Roads' as HTML",
+          "href": "https://my.server.org/sample-data/collections/roads_local/items?f=html"
+        }
+      ],
+      "id": "roads_local",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.157833237161705,
+              49.844845328102735,
+              2.6891998217837148,
+              60.75074152255422
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 3179639
+    },
+    {
+      "title": "National Roads",
+      "description": "Lines representing the road network. A road is defined as a metalled way for vehicles.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'National Roads' feature collection",
+          "href": "https://my.server.org/sample-data/collections/roads_national"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'National Roads' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/roads_national/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'National Roads' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/roads_national/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'National Roads' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/roads_national/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'National Roads' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/roads_national/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'National Roads' as HTML",
+          "href": "https://my.server.org/sample-data/collections/roads_national/items?f=html"
+        }
+      ],
+      "id": "roads_national",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -6.4956758012099645,
+              50.08021976237488,
+              2.383883951687144,
+              58.54688148276149
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 123905
+    },
+    {
+      "title": "Regional Roads",
+      "description": "Lines representing the road network. A road is defined as a metalled way for vehicles.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Regional Roads' feature collection",
+          "href": "https://my.server.org/sample-data/collections/roads_regional"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Regional Roads' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/roads_regional/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Regional Roads' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/roads_regional/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Regional Roads' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/roads_regional/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Regional Roads' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/roads_regional/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Regional Roads' as HTML",
+          "href": "https://my.server.org/sample-data/collections/roads_regional/items?f=html"
+        }
+      ],
+      "id": "roads_regional",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -8.140045163468065,
+              49.897828949470515,
+              2.678925679725326,
+              60.72856279715021
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 342709
+    },
+    {
+      "title": "Sites",
+      "description": "Polygon features that represent the area or extent of certain types of function or activity.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Sites' feature collection",
+          "href": "https://my.server.org/sample-data/collections/sites"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Sites' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/sites/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Sites' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/sites/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Sites' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/sites/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Sites' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/sites/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Sites' as HTML",
+          "href": "https://my.server.org/sample-data/collections/sites/items?f=html"
+        }
+      ],
+      "id": "sites",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -8.114938143586947,
+              49.88033059118879,
+              2.6783629940894356,
+              60.68320893890659
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 36163
+    },
+    {
+      "title": "Surface Water",
+      "description": "These polygons represent inland water bodies that are sufficiently wide enough to be captured as an area.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Surface Water' feature collection",
+          "href": "https://my.server.org/sample-data/collections/surfacewater"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Surface Water' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/surfacewater/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Surface Water' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/surfacewater/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Surface Water' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/surfacewater/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Surface Water' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/surfacewater/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Surface Water' as HTML",
+          "href": "https://my.server.org/sample-data/collections/surfacewater/items?f=html"
+        }
+      ],
+      "id": "surfacewater",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.149150953572926,
+              49.849552493410215,
+              2.6791066928139706,
+              60.78388658611872
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 520687
+    },
+    {
+      "title": "Urban Areas",
+      "description": "These are generalised polygons representing built-up areas for use at smaller scales.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Urban Areas' feature collection",
+          "href": "https://my.server.org/sample-data/collections/urban_areas"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Urban Areas' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/urban_areas/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Urban Areas' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/urban_areas/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Urban Areas' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/urban_areas/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Urban Areas' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/urban_areas/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Urban Areas' as HTML",
+          "href": "https://my.server.org/sample-data/collections/urban_areas/items?f=html"
+        }
+      ],
+      "id": "urban_areas",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -8.053765984889685,
+              49.89774857169156,
+              2.6293155160795716,
+              60.3210966112084
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 5499
+    },
+    {
+      "title": "Waterlines",
+      "description": "Lines representing rivers, canals, drains and other linear bodies of water.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Waterlines' feature collection",
+          "href": "https://my.server.org/sample-data/collections/waterlines"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Waterlines' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/waterlines/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Waterlines' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/waterlines/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Waterlines' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/waterlines/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Waterlines' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/waterlines/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Waterlines' as HTML",
+          "href": "https://my.server.org/sample-data/collections/waterlines/items?f=html"
+        }
+      ],
+      "id": "waterlines",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.23056668252574,
+              49.81680248396912,
+              2.69547862504583,
+              60.783438341201155
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 2503541
+    },
+    {
+      "title": "Woodland",
+      "description": "The polygons represent areas of trees: coniferous, non-coniferous and mixed.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Woodland' feature collection",
+          "href": "https://my.server.org/sample-data/collections/woodland"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Woodland' as JSON-FG",
+          "href": "https://my.server.org/sample-data/collections/woodland/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Woodland' as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/woodland/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Woodland' as FlatGeobuf",
+          "href": "https://my.server.org/sample-data/collections/woodland/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Woodland' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/sample-data/collections/woodland/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Woodland' as HTML",
+          "href": "https://my.server.org/sample-data/collections/woodland/items?f=html"
+        }
+      ],
+      "id": "woodland",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -8.115229230492005,
+              49.87727148846909,
+              2.67341949373892,
+              60.687673069835824
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 1285805
+    },
+    {
+      "id": "dutch-metadata",
+      "title": "Sample metadata records from Dutch Nationaal georegister",
+      "description": "Sample metadata records from Dutch Nationaal georegister",
+      "keywords": ["netherlands", "open data", "georegister"],
+      "links": [
+        {
+          "type": "text/html",
+          "rel": "canonical",
+          "title": "information",
+          "href": "https://www.nationaalgeoregister.nl",
+          "hreflang": "nl-NL"
+        },
+        {
+          "type": "application/json",
+          "rel": "root",
+          "title": "The landing page of this server as JSON",
+          "href": "https://my.server.org/sample-data?f=json"
+        },
+        {
+          "type": "text/html",
+          "rel": "root",
+          "title": "The landing page of this server as HTML",
+          "href": "https://my.server.org/sample-data?f=html"
+        },
+        {
+          "type": "application/json",
+          "rel": "self",
+          "title": "This document as JSON",
+          "href": "https://my.server.org/sample-data/collections/dutch-metadata?f=json"
+        },
+        {
+          "type": "application/ld+json",
+          "rel": "alternate",
+          "title": "This document as RDF (JSON-LD)",
+          "href": "https://my.server.org/sample-data/collections/dutch-metadata?f=jsonld"
+        },
+        {
+          "type": "text/html",
+          "rel": "alternate",
+          "title": "This document as HTML",
+          "href": "https://my.server.org/sample-data/collections/dutch-metadata?f=html"
+        },
+        {
+          "type": "application/json",
+          "rel": "queryables",
+          "title": "Queryables for this collection as JSON",
+          "href": "https://my.server.org/sample-data/collections/dutch-metadata/queryables?f=json"
+        },
+        {
+          "type": "text/html",
+          "rel": "queryables",
+          "title": "Queryables for this collection as HTML",
+          "href": "https://my.server.org/sample-data/collections/dutch-metadata/queryables?f=html"
+        },
+        {
+          "type": "application/geo+json",
+          "rel": "items",
+          "title": "items as GeoJSON",
+          "href": "https://my.server.org/sample-data/collections/dutch-metadata/items?f=json"
+        },
+        {
+          "type": "application/ld+json",
+          "rel": "items",
+          "title": "items as RDF (GeoJSON-LD)",
+          "href": "https://my.server.org/sample-data/collections/dutch-metadata/items?f=jsonld"
+        },
+        {
+          "type": "text/html",
+          "rel": "items",
+          "title": "Items as HTML",
+          "href": "https://my.server.org/sample-data/collections/dutch-metadata/items?f=html"
+        }
+      ],
+      "extent": {
+        "spatial": {
+          "bbox": [[3.37, 50.75, 7.21, 53.47]],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "record"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/collections/airports.json
+++ b/fixtures/ogc-api/sample-data/collections/airports.json
@@ -1,0 +1,113 @@
+{
+  "title": "Airports",
+  "description": "A centre point for all major airports including a name.",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data/collections/airports?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/collections/airports?f=html"
+    },
+    {
+      "rel": "alternate",
+      "type": "application/xml",
+      "title": "This document as XML",
+      "href": "https://my.server.org/sample-data/collections/airports?f=xml"
+    },
+    {
+      "rel": "license",
+      "title": "Open Government Licence (OGL)",
+      "href": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+      "title": "Queryable attributes",
+      "href": "https://my.server.org/sample-data/collections/airports/queryables"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/sortables",
+      "title": "Sortable attributes",
+      "href": "https://my.server.org/sample-data/collections/airports/sortables"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/0.0/schema-item",
+      "title": "Schema of features in 'Airports'",
+      "href": "https://my.server.org/sample-data/collections/airports/schemas/feature"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/0.0/schema-collection",
+      "title": "Schema of feature collections in 'Airports'",
+      "href": "https://my.server.org/sample-data/collections/airports/schemas/collection"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/styles",
+      "title": "Styles to render the data in maps",
+      "href": "https://my.server.org/sample-data/collections/airports/styles"
+    },
+    {
+      "rel": "ldp-map",
+      "title": "Access a web map with the data",
+      "href": "https://my.server.org/sample-data/collections/airports/styles/Road?f=html"
+    },
+    {
+      "rel": "items",
+      "type": "application/vnd.ogc.fg+json",
+      "title": "Access the features in the collection 'Airports' as JSON-FG",
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=jsonfg"
+    },
+    {
+      "rel": "items",
+      "type": "application/geo+json",
+      "title": "Access the features in the collection 'Airports' as GeoJSON",
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=json"
+    },
+    {
+      "rel": "items",
+      "type": "application/flatgeobuf",
+      "title": "Access the features in the collection 'Airports' as FlatGeobuf",
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=fgb"
+    },
+    {
+      "rel": "items",
+      "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+      "title": "Access the features in the collection 'Airports' as JSON-FG (GeoJSON Compatibility Mode)",
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=jsonfgc"
+    },
+    {
+      "rel": "items",
+      "type": "text/html",
+      "title": "Access the features in the collection 'Airports' as HTML",
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=html"
+    }
+  ],
+  "id": "airports",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -7.942759150065165,
+          49.901607895996534,
+          1.9957427933628138,
+          60.133709755754
+        ]
+      ],
+      "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+    }
+  },
+  "itemType": "feature",
+  "crs": [
+    "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "http://www.opengis.net/def/crs/EPSG/0/27700",
+    "http://www.opengis.net/def/crs/EPSG/0/4258",
+    "http://www.opengis.net/def/crs/EPSG/0/4326",
+    "http://www.opengis.net/def/crs/EPSG/0/3857"
+  ],
+  "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+  "itemCount": 46
+}

--- a/fixtures/ogc-api/sample-data/collections/airports/items.json
+++ b/fixtures/ogc-api/sample-data/collections/airports/items.json
@@ -1,0 +1,107 @@
+{
+  "type": "FeatureCollection",
+  "numberReturned": 10,
+  "timeStamp": "2023-01-08T12:25:28Z",
+  "features": [
+    {
+      "type": "Feature",
+      "id": 1,
+      "geometry": { "type": "Point", "coordinates": [-1.2918826, 59.8783475] },
+      "properties": { "name": "Sumburgh Airport" }
+    },
+    {
+      "type": "Feature",
+      "id": 2,
+      "geometry": { "type": "Point", "coordinates": [-1.2438161, 60.1918282] },
+      "properties": { "name": "Tingwall Airport" }
+    },
+    {
+      "type": "Feature",
+      "id": 3,
+      "geometry": { "type": "Point", "coordinates": [-2.8998525, 58.9579506] },
+      "properties": { "name": "Kirkwall Airport" }
+    },
+    {
+      "type": "Feature",
+      "id": 4,
+      "geometry": { "type": "Point", "coordinates": [-6.3295078, 58.2138995] },
+      "properties": { "name": "Port-Adhair Steòrnabhaigh/Stornoway Airport" }
+    },
+    {
+      "type": "Feature",
+      "id": 5,
+      "geometry": { "type": "Point", "coordinates": [-3.094033, 58.458363] },
+      "properties": { "name": "Wick John O'Groats Airport" }
+    },
+    {
+      "type": "Feature",
+      "id": 6,
+      "geometry": { "type": "Point", "coordinates": [-7.3610346, 57.4843261] },
+      "properties": {
+        "name": "Port-adhair Bheinn na Faoghla/Benbecula Airport"
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 7,
+      "geometry": { "type": "Point", "coordinates": [-7.4487268, 57.0254269] },
+      "properties": { "name": "Port-adhair Bharraigh/Barra Airport" }
+    },
+    {
+      "type": "Feature",
+      "id": 8,
+      "geometry": { "type": "Point", "coordinates": [-4.0493507, 57.5431458] },
+      "properties": { "name": "Inverness Airport" }
+    },
+    {
+      "type": "Feature",
+      "id": 9,
+      "geometry": { "type": "Point", "coordinates": [-2.200068, 57.202807] },
+      "properties": { "name": "Aberdeen International Airport" }
+    },
+    {
+      "type": "Feature",
+      "id": 10,
+      "geometry": { "type": "Point", "coordinates": [-6.869044, 56.5011563] },
+      "properties": { "name": "Tiree Airport" }
+    }
+  ],
+  "links": [
+    {
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=json",
+      "rel": "self",
+      "type": "application/geo+json",
+      "title": "This document"
+    },
+    {
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=jsonfgc",
+      "rel": "alternate",
+      "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+      "title": "This document as JSON-FG (GeoJSON Compatibility Mode)"
+    },
+    {
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=fgb",
+      "rel": "alternate",
+      "type": "application/flatgeobuf",
+      "title": "This document as FlatGeobuf"
+    },
+    {
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=html",
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML"
+    },
+    {
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=jsonfg",
+      "rel": "alternate",
+      "type": "application/vnd.ogc.fg+json",
+      "title": "This document as JSON-FG"
+    },
+    {
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=json&offset=10",
+      "rel": "next",
+      "type": "application/geo+json",
+      "title": "Next page"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/collections/airports/items/1.json
+++ b/fixtures/ogc-api/sample-data/collections/airports/items/1.json
@@ -1,0 +1,44 @@
+{
+  "type": "Feature",
+  "id": 1,
+  "geometry": { "type": "Point", "coordinates": [-1.2918826, 59.8783475] },
+  "properties": { "name": "Sumburgh Airport" },
+  "links": [
+    {
+      "href": "https://demo.ldproxy.net/zoomstack/collections/airports/items/1?f=json",
+      "rel": "self",
+      "type": "application/geo+json",
+      "title": "This document"
+    },
+    {
+      "href": "https://demo.ldproxy.net/zoomstack/collections/airports/items/1?f=jsonfgc",
+      "rel": "alternate",
+      "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+      "title": "This document as JSON-FG (GeoJSON Compatibility Mode)"
+    },
+    {
+      "href": "https://demo.ldproxy.net/zoomstack/collections/airports/items/1?f=fgb",
+      "rel": "alternate",
+      "type": "application/flatgeobuf",
+      "title": "This document as FlatGeobuf"
+    },
+    {
+      "href": "https://demo.ldproxy.net/zoomstack/collections/airports/items/1?f=html",
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML"
+    },
+    {
+      "href": "https://demo.ldproxy.net/zoomstack/collections/airports/items/1?f=jsonfg",
+      "rel": "alternate",
+      "type": "application/vnd.ogc.fg+json",
+      "title": "This document as JSON-FG"
+    },
+    {
+      "href": "https://demo.ldproxy.net/zoomstack/collections/airports?f=json",
+      "rel": "collection",
+      "type": "application/json",
+      "title": "The collection the feature belongs to"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/collections/airports/queryables.json
+++ b/fixtures/ogc-api/sample-data/collections/airports/queryables.json
@@ -1,0 +1,17 @@
+{
+  "title": "Airports",
+  "description": "A centre point for all major airports including a name.",
+  "properties": {
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "geom": {
+      "$ref": "https://geojson.org/schema/Point.json"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://my.server.org/sample-data/collections/airports/queryables"
+}

--- a/fixtures/ogc-api/sample-data/collections/airports/schemas/collection.json
+++ b/fixtures/ogc-api/sample-data/collections/airports/schemas/collection.json
@@ -1,0 +1,57 @@
+{
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["FeatureCollection"]
+    },
+    "links": {
+      "items": {
+        "$ref": "#/$defs/Link"
+      },
+      "type": "array"
+    },
+    "timeStamp": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "numberMatched": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "numberReturned": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "features": {
+      "items": {
+        "$ref": "https://my.server.org/sample-data/collections/airports/schemas/feature"
+      },
+      "type": "array"
+    }
+  },
+  "type": "object",
+  "required": ["type", "features"],
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://my.server.org/sample-data/collections/airports/schemas/collection",
+  "$defs": {
+    "Link": {
+      "properties": {
+        "href": {
+          "format": "uri-reference",
+          "type": "string"
+        },
+        "rel": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": ["href"]
+    }
+  }
+}

--- a/fixtures/ogc-api/sample-data/collections/airports/schemas/feature.json
+++ b/fixtures/ogc-api/sample-data/collections/airports/schemas/feature.json
@@ -1,0 +1,79 @@
+{
+  "title": "Airports",
+  "description": "A centre point for all major airports including a name.",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["Feature"]
+    },
+    "links": {
+      "items": {
+        "$ref": "#/$defs/Link"
+      },
+      "type": "array"
+    },
+    "id": {
+      "type": "integer"
+    },
+    "geometry": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "title": "GeoJSON Point",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["Point"]
+            },
+            "coordinates": {
+              "items": {
+                "type": "number"
+              },
+              "minItems": 2,
+              "maxItems": 3,
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "required": ["type", "coordinates"]
+        }
+      ]
+    },
+    "properties": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "required": ["type", "geometry", "properties"],
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://my.server.org/sample-data/collections/airports/schemas/feature",
+  "$defs": {
+    "Link": {
+      "properties": {
+        "href": {
+          "format": "uri-reference",
+          "type": "string"
+        },
+        "rel": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": ["href"]
+    }
+  }
+}

--- a/fixtures/ogc-api/sample-data/collections/airports/sortables.json
+++ b/fixtures/ogc-api/sample-data/collections/airports/sortables.json
@@ -1,0 +1,14 @@
+{
+  "title": "Airports",
+  "description": "A centre point for all major airports including a name.",
+  "properties": {
+    "name": {
+      "title": "Name",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://my.server.org/sample-data/collections/airports/sortables"
+}

--- a/fixtures/ogc-api/sample-data/collections/airports/styles.json
+++ b/fixtures/ogc-api/sample-data/collections/airports/styles.json
@@ -1,0 +1,227 @@
+{
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data/collections/airports/styles?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/collections/airports/styles?f=html"
+    }
+  ],
+  "styles": [
+    {
+      "title": "Deuteranopia",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Deuteranopia?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Deuteranopia?f=sld10"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Deuteranopia/metadata"
+        }
+      ],
+      "id": "Deuteranopia"
+    },
+    {
+      "title": "Light",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Light?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Light?f=sld10"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "text/html",
+          "title": "Web map using the style",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Light?f=html"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.mapbox.style+json",
+          "title": "Style in format 'Mapbox'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Light?f=mbs"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Light/metadata"
+        }
+      ],
+      "id": "Light"
+    },
+    {
+      "title": "Night",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Night?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Night?f=sld10"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "text/html",
+          "title": "Web map using the style",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Night?f=html"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.mapbox.style+json",
+          "title": "Style in format 'Mapbox'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Night?f=mbs"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Night/metadata"
+        }
+      ],
+      "id": "Night"
+    },
+    {
+      "title": "Outdoor",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Outdoor?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Outdoor?f=sld10"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "text/html",
+          "title": "Web map using the style",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Outdoor?f=html"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.mapbox.style+json",
+          "title": "Style in format 'Mapbox'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Outdoor?f=mbs"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Outdoor/metadata"
+        }
+      ],
+      "id": "Outdoor"
+    },
+    {
+      "title": "Road",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Road?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Road?f=sld10"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "text/html",
+          "title": "Web map using the style",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Road?f=html"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.mapbox.style+json",
+          "title": "Style in format 'Mapbox'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Road?f=mbs"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Road/metadata"
+        }
+      ],
+      "id": "Road"
+    },
+    {
+      "title": "Tritanopia",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=sld10"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/Tritanopia/metadata"
+        }
+      ],
+      "id": "Tritanopia"
+    },
+    {
+      "title": "OS Open Zoomstack - Outdoor with Hillshade",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "text/html",
+          "title": "Web map using the style",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/OutdoorHillshade?f=html"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.mapbox.style+json",
+          "title": "Style in format 'Mapbox'",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/OutdoorHillshade?f=mbs"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/airports/styles/OutdoorHillshade/metadata"
+        }
+      ],
+      "id": "OutdoorHillshade"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/collections/dutch-metadata.json
+++ b/fixtures/ogc-api/sample-data/collections/dutch-metadata.json
@@ -1,0 +1,82 @@
+{
+  "id": "dutch-metadata",
+  "title": "Sample metadata records from Dutch Nationaal georegister",
+  "description": "Sample metadata records from Dutch Nationaal georegister",
+  "keywords": ["netherlands", "open data", "georegister"],
+  "links": [
+    {
+      "type": "text/html",
+      "rel": "canonical",
+      "title": "information",
+      "href": "https://www.nationaalgeoregister.nl",
+      "hreflang": "nl-NL"
+    },
+    {
+      "type": "application/json",
+      "rel": "root",
+      "title": "The landing page of this server as JSON",
+      "href": "https://my.server.org/sample-data?f=json"
+    },
+    {
+      "type": "text/html",
+      "rel": "root",
+      "title": "The landing page of this server as HTML",
+      "href": "https://my.server.org/sample-data?f=html"
+    },
+    {
+      "type": "application/json",
+      "rel": "self",
+      "title": "This document as JSON",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata?f=json"
+    },
+    {
+      "type": "application/ld+json",
+      "rel": "alternate",
+      "title": "This document as RDF (JSON-LD)",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata?f=jsonld"
+    },
+    {
+      "type": "text/html",
+      "rel": "alternate",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata?f=html"
+    },
+    {
+      "type": "application/json",
+      "rel": "queryables",
+      "title": "Queryables for this collection as JSON",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata/queryables?f=json"
+    },
+    {
+      "type": "text/html",
+      "rel": "queryables",
+      "title": "Queryables for this collection as HTML",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata/queryables?f=html"
+    },
+    {
+      "type": "application/geo+json",
+      "rel": "items",
+      "title": "items as GeoJSON",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata/items?f=json"
+    },
+    {
+      "type": "application/ld+json",
+      "rel": "items",
+      "title": "items as RDF (GeoJSON-LD)",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata/items?f=jsonld"
+    },
+    {
+      "type": "text/html",
+      "rel": "items",
+      "title": "Items as HTML",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata/items?f=html"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [[3.37, 50.75, 7.21, 53.47]],
+      "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+    }
+  },
+  "itemType": "record"
+}

--- a/fixtures/ogc-api/sample-data/collections/dutch-metadata/items.json
+++ b/fixtures/ogc-api/sample-data/collections/dutch-metadata/items.json
@@ -1,0 +1,746 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "id": "35149dfb-31d3-431c-a8bc-12a4034dac48",
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [4.690751953125, 52.358740234375],
+            [4.690751953125, 52.6333984375],
+            [5.020341796875, 52.6333984375],
+            [5.020341796875, 52.358740234375],
+            [4.690751953125, 52.358740234375]
+          ]
+        ]
+      },
+      "properties": {
+        "recordCreated": "2021-12-08",
+        "recordUpdated": "2022-06-10T01:27:47Z",
+        "type": "dataset",
+        "title": "Kaartboeck 1635",
+        "description": "Data uit kaartboeken van de periode 1635 tot 1775. De kaartboeken werden door het waterschap gebruikt om er op toe te zien dat de eigenaren geen water in beslag namen door demping.\nDe percelen op de kaart zijn naar de huidige maatstaven vrij nauwkeurig gemeten en voorzien van een administratie met de eigenaren. bijzondere locaties van molens werven en beroepen worden in de boeken vermeld. Alle 97 kaarten aan een geven een zeer gedetailleerd beeld van de Voorzaan, Nieuwe Haven en de Achterzaan. De bladen Oost en West van de zaan zijn vrij nauwkeurig. De bladen aan de Voorzaan zijn een schetsmatige weergave van de situatie. De kaart van de Nieuwe Haven si weer nauwkeurig te noemen.",
+        "providers": [
+          "Team Geo, geo-informatie@zaanstad.nl, Gemeente Zaanstad"
+        ],
+        "externalIds": [
+          {
+            "scheme": "default",
+            "value": "35149dfb-31d3-431c-a8bc-12a4034dac48"
+          }
+        ],
+        "themes": [
+          {
+            "concepts": [
+              "ARGEOLOGIE",
+              "MONUMENTEN",
+              "KADASTER",
+              "KAARTBOEK",
+              "KAARTBOECK",
+              "HISTORIE"
+            ]
+          }
+        ],
+        "extent": {
+          "spatial": {
+            "bbox": [
+              [4.690751953125, 52.358740234375, 5.020341796875, 52.6333984375]
+            ],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "temporal": {
+            "interval": [null, null],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "https://maps-intern.zaanstad.gem.local/geoserver/wms?SERVICE=WMS",
+          "rel": "item",
+          "title": "geo:kaartboeck",
+          "type": "OGC:WMS"
+        },
+        {
+          "href": "https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS",
+          "rel": "item",
+          "title": "geo:kaartboeck",
+          "type": "OGC:WFS"
+        },
+        {
+          "href": "https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=geo:kaartboeck&outputFormat=csv",
+          "rel": "item",
+          "type": "download"
+        },
+        {
+          "href": "https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=geo:kaartboeck&outputFormat=shape-zip",
+          "rel": "item",
+          "type": "download"
+        }
+      ]
+    },
+    {
+      "id": "ffffffaa-4087-59ec-9ea7-8416f58e99dd",
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [4.4552947, 52.3348457],
+            [4.4552947, 53.388444],
+            [7.135964, 53.388444],
+            [7.135964, 52.3348457],
+            [4.4552947, 52.3348457]
+          ]
+        ]
+      },
+      "properties": {
+        "recordCreated": "2022-06-01",
+        "recordUpdated": "2022-06-10T01:27:47Z",
+        "type": "dataset",
+        "title": "Diepteligging onderkant keileem (t.o.v. NAP)",
+        "description": "Diepteligging van de onderkant (basis) van keileem in Drenthe, in meters ten opzichte van NAP.",
+        "providers": [
+          "Team Gis/Cartografie, post@drenthe.nl, Provincie Drenthe"
+        ],
+        "externalIds": [
+          {
+            "scheme": "default",
+            "value": "ffffffaa-4087-59ec-9ea7-8416f58e99dd"
+          }
+        ],
+        "themes": [
+          {
+            "concepts": [
+              "beleidsinstrument",
+              "bodem",
+              "grondwaterstand",
+              "landbouw",
+              "landbouwgrond",
+              "waterhuishouding"
+            ],
+            "scheme": null
+          }
+        ],
+        "extent": {
+          "spatial": {
+            "bbox": [[4.4552947, 52.3348457, 7.135964, 53.388444]],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "temporal": {
+            "interval": [null, null],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "https://kaartportaal.drenthe.nl/server/services/GDB_actueel/GBI_KEILEEM_DIEPTE_ONDER_NAP_R/MapServer/WMSServer",
+          "rel": "item",
+          "title": "0",
+          "type": "OGC:WMS"
+        }
+      ]
+    },
+    {
+      "id": "59352e7f-3792-4e17-bd73-9bba84a98890",
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [4.79, 51.857],
+            [4.79, 52.305],
+            [5.63, 52.305],
+            [5.63, 51.857],
+            [4.79, 51.857]
+          ]
+        ]
+      },
+      "properties": {
+        "recordCreated": "2021-06-30",
+        "recordUpdated": "2022-06-10T01:27:47Z",
+        "type": "dataset",
+        "title": "Clusters geluid - wegen gecumuleerd",
+        "description": "Clusters (omtreklijn) gebaseerd op gemeentegrenzen. Per cluster zijn de aantallen woningen en gevoelige bestemmingen per GES-score geteld. Bij de gevoelige bestemmingen is onderscheid gemaakt in 3 categorien: Ziekenhuizen, Scholen en dagverblijven voor jeugd, Verpleeg en verzorgingshuizen.",
+        "providers": ["GIS, GIS@provincie-utrecht.nl, Provincie Utrecht"],
+        "externalIds": [
+          {
+            "scheme": "default",
+            "value": "59352e7f-3792-4e17-bd73-9bba84a98890"
+          }
+        ],
+        "themes": [
+          {
+            "concepts": [
+              "GELUIDHINDER",
+              "GELUIDSZONES",
+              "PROVINCIALE WEGEN",
+              "VERKEERSLAWAAI",
+              "WET GELUIDHINDER"
+            ],
+            "scheme": null
+          },
+          {
+            "concepts": ["Informatief"],
+            "scheme": null
+          }
+        ],
+        "extent": {
+          "spatial": {
+            "bbox": [[4.79, 51.857, 5.63, 52.305]],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "temporal": {
+            "interval": [null, null],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "https://download.geodata-utrecht.nl/download/vector/59352e7f-3792-4e17-bd73-9bba84a98890",
+          "rel": "item",
+          "type": "landingpage"
+        },
+        {
+          "href": "https://services.geodata-utrecht.nl/geoserver/m01_4_overlast_hinder_mgkp/wfs",
+          "rel": "item",
+          "title": "Clusters_geluid_-_wegen_gecumuleerd",
+          "type": "OGC:WFS"
+        },
+        {
+          "href": "https://services.geodata-utrecht.nl/geoserver/m01_4_overlast_hinder_mgkp/wms",
+          "rel": "item",
+          "title": "Clusters_geluid_-_wegen_gecumuleerd",
+          "type": "OGC:WMS"
+        }
+      ]
+    },
+    {
+      "id": "0ec79c96-898f-40da-adc7-673eb4749685",
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [4.1407, 52.004],
+            [4.1407, 52.9215],
+            [4.8927, 52.9215],
+            [4.8927, 52.004],
+            [4.1407, 52.004]
+          ]
+        ]
+      },
+      "properties": {
+        "recordCreated": "2022-02-02",
+        "recordUpdated": "2022-06-10T01:27:47Z",
+        "type": "dataset",
+        "title": "Geesten van Holland",
+        "description": "In de dataset 'Geesten' zijn de locaties opgenomen van middeleeuwse akkercomplexen op de strandwallen in Noord- en Zuid-Holland.",
+        "providers": [
+          "InfoDesk, info@cultureelerfgoed.nl, Rijksdienst voor het Cultureel Erfgoed"
+        ],
+        "externalIds": [
+          {
+            "scheme": "default",
+            "value": "0ec79c96-898f-40da-adc7-673eb4749685"
+          }
+        ],
+        "themes": [
+          {
+            "concepts": []
+          }
+        ],
+        "extent": {
+          "spatial": {
+            "bbox": [[4.1407, 52.004, 4.8927, 52.9215]],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "temporal": {
+            "interval": [null, null],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "https://services.rce.geovoorziening.nl/landschapsatlas/wms?&request=GetCapabilities",
+          "rel": "item",
+          "title": "Geesten"
+        },
+        {
+          "href": "https://services.rce.geovoorziening.nl/landschapsatlas/wfs?&request=GetCapabilities",
+          "rel": "item",
+          "title": "landschapsatlas:Geesten"
+        }
+      ]
+    },
+    {
+      "id": "364c5d7a-d6ec-11ea-87d0-0242ac130003",
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [3.2, 50.75],
+            [3.2, 53.7],
+            [7.22, 53.7],
+            [7.22, 50.75],
+            [3.2, 50.75]
+          ]
+        ]
+      },
+      "properties": {
+        "recordCreated": "2021-06-18",
+        "recordUpdated": "2022-06-10T01:27:47Z",
+        "type": "service",
+        "title": "Grondwaterstandsonderzoek, downloadservice",
+        "description": "Gegevens over grondwaterstandsonderzoek (Groundwaterlevel data in het Engels) zijn opgeslagen in de basisregistratie ondergrond (BRO). Het registratieobject grondwaterstandonderzoek bevat de metingen van de variatie in de stand van het grondwater dat in een bekende grondwatermonitoringput met een zekere buis wordt ontsloten.\nMet het monitoren van het grondwater gebeurt al lange tijd, op vele locaties in ons land. Met die informatie is het mogelijk om karakteristieke kenmerken van de beweging van het grondwater vast te stellen, ruimtelijke patronen te herkennen en trendmatige veranderingen te analyseren.\nBelangrijke kenmerken zijn bijvoorbeeld de hoogste en laatste grondwaterstand die in een bepaald gebied zijn te verwachten als gevolg van het jaarlijkse seizoenpatroon. Die kennis is niet alleen van belang voor de landbouw en natuurontwikkeling, maar ook voor het ontwerpen van nieuwe woonwijken en infrastructuur.\nDe meetgegevens geven inzicht in de reactie van het grondwater op  veranderingen zoals de verlaging van een polderpeil, of grondwaterwinning. Op basis van die informatie kunnen voorspellingen worden gedaan over het verloop van de grondwaterstand in de toekomst. Hoe langer de tijdreeksen zijn, des te nauwkeuriger de voorspellingen zijn over het lange termijn gedrag van het grondwater.\nEen van de belangrijke uitdagingen van nu is het voorspellen van de invloed van de klimaatverandering op het grondwatersysteem. Zowel in nationaal als internationaal verband worden richtlijnen ontwikkeld voor een duurzaam beleid en beheer van onze grondwatersystemen.",
+        "providers": [
+          "support@broservicedesk.nl, TNO Geologische Dienst Nederland"
+        ],
+        "externalIds": [
+          {
+            "scheme": "default",
+            "value": "364c5d7a-d6ec-11ea-87d0-0242ac130003"
+          }
+        ],
+        "themes": [
+          {
+            "concepts": ["infoMapAccessService"]
+          },
+          {
+            "concepts": [
+              "basisregistratie ondergrond",
+              "bro",
+              "GMN",
+              "grondwatermonitoring",
+              "grondwatermonitoringnet",
+              "grondwateronderzoek",
+              "grondwaterstand"
+            ],
+            "scheme": null
+          }
+        ],
+        "extent": {
+          "spatial": {
+            "bbox": [[3.2, 50.75, 7.22, 53.7]],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "temporal": {
+            "interval": [null, null],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+          }
+        }
+      },
+      "links": []
+    },
+    {
+      "id": "7B40133214B7456CE053D2041EACD771",
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [6.105, 52.601],
+            [6.105, 53.213],
+            [7.109, 53.213],
+            [7.109, 52.601],
+            [6.105, 52.601]
+          ]
+        ]
+      },
+      "properties": {
+        "recordCreated": "2022-06-01",
+        "recordUpdated": "2022-06-10T01:27:47Z",
+        "type": "dataset",
+        "title": "Hemelhelderheidskaart",
+        "description": "Hemelhelderheid Drenthe met kasverlichting gedoofd (2015-2016). De grootheid luminantie (helderheid) kent verschillende eenheden en die worden in de kaart weergegeven. De eenheid candela per vierkante meter is de eenheid die verlichtingsdeskundigen gebruiken om te meten hoeveel licht ergens op straalt. De gebruikte eenheid mcd/m2 is een duizendste cd/m2. De eenheid magnitude wordt gebruikt door sterrenkundigen. Hoe helderder de hemel, hoe hoger het getal in candela per vierkante meter, hoe meer licht er van de hemel komt.",
+        "providers": [
+          "Team Gis/Cartografie, post@drenthe.nl, Provincie Drenthe"
+        ],
+        "externalIds": [
+          {
+            "scheme": "default",
+            "value": "7B40133214B7456CE053D2041EACD771"
+          }
+        ],
+        "themes": [
+          {
+            "concepts": ["locaties"],
+            "scheme": null
+          }
+        ],
+        "extent": {
+          "spatial": {
+            "bbox": [[6.105, 52.601, 7.109, 53.213]],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "temporal": {
+            "interval": [null, null],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "https://kaartportaal.drenthe.nl/server/services/GDB_actueel/GBI_MILIEU_HEMELHELDERHEID_V/MapServer/WMSServer",
+          "rel": "item",
+          "title": "0",
+          "type": "OGC:WMS"
+        },
+        {
+          "href": "https://kaartportaal.drenthe.nl/server/services/GDB_actueel/GBI_MILIEU_HEMELHELDERHEID_V/MapServer/WFSServer",
+          "rel": "item",
+          "title": "esri:Hemelhelderheidskaart",
+          "type": "OGC:WFS"
+        }
+      ]
+    },
+    {
+      "id": "1da54925-0085-4972-bdec-47bef653fc16",
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [3.15, 50.6],
+            [3.15, 53.6],
+            [7.3, 53.6],
+            [7.3, 50.6],
+            [3.15, 50.6]
+          ]
+        ]
+      },
+      "properties": {
+        "recordCreated": "2020-12-21",
+        "recordUpdated": "2022-06-10T01:27:47Z",
+        "type": "service",
+        "title": "WarmteAtlas WMS",
+        "description": "Atlas voor kaarten over het warmte gebruik (industrie, glastuinbouw en huishoudens) en potentieel kaarten voor de productie van duurzame warmte en de aanwezigheid van nog niet benutte restwarmte.",
+        "providers": [
+          "klantcontact, klantcontact@rvo.nl, Rijksdienst voor Ondernemend Nederland (RvO)"
+        ],
+        "externalIds": [
+          {
+            "scheme": "default",
+            "value": "1da54925-0085-4972-bdec-47bef653fc16"
+          }
+        ],
+        "themes": [
+          {
+            "concepts": [
+              "infoMapAccessService",
+              "Energie",
+              "Warmte",
+              "Biogas",
+              "Aardwarmte",
+              "Thermische Energie Oppervlaktewater TEO",
+              "Warmte Koude Opslag WKO",
+              "Gebouwde Omgeving",
+              "Industrie",
+              "CO2 emissie",
+              "Glastuinbouw",
+              "Grote Stook Installaties",
+              "IBIS Bedrijventerreinen",
+              "Grote Gebouwen",
+              "Warmtenetten",
+              "Aardwarmte",
+              "Biomassa",
+              "Energie vraag",
+              "Woonkernen",
+              "Kassen",
+              "WarmteAtlas"
+            ]
+          },
+          {
+            "concepts": ["Energiebronnen"],
+            "scheme": null
+          },
+          {
+            "concepts": [
+              "Energie",
+              "Warmte",
+              "Industrie",
+              "Kassen",
+              "Bedrijventerreinen",
+              "Grote Stook Installaties",
+              "Grote Gebouwen",
+              "Woonkernen",
+              "Warmtenetten",
+              "Warmte Vraag",
+              "Warmte Potentieel",
+              "Nationaal",
+              "Glastuinbouw",
+              "WarmteAtlas",
+              "Energie Verbruik",
+              "Energie",
+              null
+            ],
+            "scheme": null
+          }
+        ],
+        "extent": {
+          "spatial": {
+            "bbox": [[3.15, 50.6, 7.3, 53.6]],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "temporal": {
+            "interval": [null, null],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "https://rvo.b3p.nl/geoserver/WarmteAtlas/wms?",
+          "rel": "item",
+          "title": "WarmteAtlas WMS",
+          "type": "OGC:WMS"
+        }
+      ]
+    },
+    {
+      "id": "efc55744-a8f5-40e1-8d15-1ffa7a018988",
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [3.37087, 50.7539],
+            [3.37087, 53.4658],
+            [7.21097, 53.4658],
+            [7.21097, 50.7539],
+            [3.37087, 50.7539]
+          ]
+        ]
+      },
+      "properties": {
+        "recordCreated": "2021-12-22",
+        "recordUpdated": "2022-06-10T01:27:47Z",
+        "type": "dataset",
+        "title": "DANK-Delfstofwinning op land: zand, grind en klei",
+        "description": "De kaart geeft de geologische winbare hoeveelheid zand, grind en klei weer wanneer er niet meer dan maximaal 5 meter aan deklaag moet worden afgegraven.\n\n                    Voor de productie van veel bouwmaterialen wordt gebruik gemaakt van oppervlaktedelfstoffen. In Nederland is jaarlijks circa 150 miljoen ton aan bouwgrondstoffen nodig. Een deel daarvan komt uit het buitenland, een deel wordt verkregen door hergebruik (15 tot 20 %), maar nog steeds wordt een groot deel verkregen uit primaire winning.\n\n                    Sinds 1900 is de winning van ophoogzand op verschillende locaties uitgevoerd door maaiveldverlaging in het kader van\n                    landbouwkundige verbeteringen (ruilverkaveling).\n                    Sinds de jaren zeventig is er een afname in oppervlakkig ontgronden door toenemende maatschappelijke weerstand en strengere wetgevingen. Zandwinning vindt nu voornamelijk plaats in geconcentreerde winputten. Aanvullend vindt winning plaats middels het \"werk met werk maken\" principe. Hierin wordt bijvoorbeeld in nieuwbouwprojecten zand gewonnen voor gebruik in het project en tegelijkertijd waterberging gecre\u00eberd.\n                    Voor winning van oppervlaktedelfstoffen is per jaar circa 400 hectare oppervlakte van ons land noodzakelijk. Ongeveer de helft daarvan, circa 200 hectare, blijft achter als diep water. De andere 200 hectare krijgt via herinrichting een nieuwe ruimtelijke bestemming, bijvoorbeeld als natuur- of recreatiegebied. Alternatief is de winning van zand uit het IJsselmeer, de Randmeren en de Noordzee. De winning van grind is vooral voorzien plaats te vinden uit de maaswerken in Limburg.\n                    De winning en reservering van zand en grind zijn bij de wet geregeld en land based winlocaties worden door de provincie aangewezen. De winning van zand en grind legt een ruimtebeslag die enerzijds kan conflicteren met ander gebruik, anderzijds kan ook de winning samengaan met inrichtingsvraagstukken zoals het geven van ruimte voor de rivieren en tijdelijke waterberging.",
+        "providers": [
+          "atlasnatuurlijkkapitaal@rivm.nl, Atlas Natuurlijk Kapitaal"
+        ],
+        "externalIds": [
+          {
+            "scheme": "default",
+            "value": "efc55744-a8f5-40e1-8d15-1ffa7a018988"
+          }
+        ],
+        "themes": [
+          {
+            "concepts": ["winning zand grid diepte nederland"]
+          }
+        ],
+        "extent": {
+          "spatial": {
+            "bbox": [[3.37087, 50.7539, 7.21097, 53.4658]],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "temporal": {
+            "interval": [null, null],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "http://data.rivm.nl/geo/ank/wms?",
+          "rel": "item",
+          "title": "d022_delftstofwinning_op_land_en_in_binnenwateren_rivier",
+          "type": "OGC:WMS"
+        },
+        {
+          "href": "https://data.rivm.nl/meta/srv/api/records/efc55744-a8f5-40e1-8d15-1ffa7a018988/attachments/DANK022_delfstofwinning_op_land_en_in_binnenwateren_rivier.zip",
+          "rel": "item",
+          "title": "DANK022_delfstofwinning_op_land_en_in_binnenwateren_rivier.zip",
+          "type": "download"
+        }
+      ]
+    },
+    {
+      "id": "826735d1-1467-4888-9829-61019c033431",
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [4.690751953125, 52.358740234375],
+            [4.690751953125, 52.6333984375],
+            [5.020341796875, 52.6333984375],
+            [5.020341796875, 52.358740234375],
+            [4.690751953125, 52.358740234375]
+          ]
+        ]
+      },
+      "properties": {
+        "recordCreated": "2021-11-17",
+        "recordUpdated": "2022-06-10T01:27:47Z",
+        "type": "dataset",
+        "title": "Luchtfoto 2018",
+        "description": "Een luchtfoto is een afbeelding van een gedeelte van het aardoppervlak, gefotografeerd van uit een hoog standpunt los van het aardoppervlak, veelal vanuit een luchtvaartuig.",
+        "providers": [
+          "Team Geo, geo-informatie@zaanstad.nl, Gemeente Zaanstad"
+        ],
+        "externalIds": [
+          {
+            "scheme": "default",
+            "value": "826735d1-1467-4888-9829-61019c033431"
+          }
+        ],
+        "themes": [
+          {
+            "concepts": [
+              "FOTO",
+              "LUCHTFOTO",
+              "REFERENTIEKAART",
+              "TOPOGRAFIE",
+              "2018",
+              "LUFO",
+              null
+            ]
+          }
+        ],
+        "extent": {
+          "spatial": {
+            "bbox": [
+              [4.690751953125, 52.358740234375, 5.020341796875, 52.6333984375]
+            ],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "temporal": {
+            "interval": [null, null],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "https://tiles.zaanstad.nl/mapproxy/service?SERVICE=WMS",
+          "rel": "item",
+          "title": "Lufo2018-kleur",
+          "type": "OGC:WMS"
+        },
+        {
+          "href": "https://tiles.zaanstad.nl/mapproxy/service?SERVICE=WFS",
+          "rel": "item",
+          "title": "Lufo2018-kleur",
+          "type": "OGC:WFS"
+        },
+        {
+          "href": "https://tiles.zaanstad.nl/mapproxy/service?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=Lufo2018-kleur&outputFormat=csv",
+          "rel": "item",
+          "title": "CSV",
+          "type": "download"
+        },
+        {
+          "href": "https://tiles.zaanstad.nl/mapproxy/service?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=Lufo2018-kleur&outputFormat=shape-zip",
+          "rel": "item",
+          "title": "Shape-zip",
+          "type": "download"
+        }
+      ]
+    },
+    {
+      "id": "b7d2fd24-8cd8-4965-a997-69eb1a987b5a",
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [3.37087, 50.7539],
+            [3.37087, 53.4658],
+            [7.21097, 53.4658],
+            [7.21097, 50.7539],
+            [3.37087, 50.7539]
+          ]
+        ]
+      },
+      "properties": {
+        "recordCreated": "2019-04-16",
+        "recordUpdated": "2022-06-10T01:27:47Z",
+        "type": "dataset",
+        "title": "Zonpotentie velden",
+        "description": "In deze kaartlaag zijn denkbare locaties voor zonnepanelen in veldopstelling aangegeven. Het gaat hier om kleine terreinen (tussen 0,5 en 1,0 hectare), middelgrote terreinen (tussen 1,0 en 3,0 hectare) en grote terreinen (3,0 hectare en groter). Te zien zijn gras- en akkerlanden buiten de bebouwing, exclusief gebieden die tot Natura2000 behoren.\n\nVoor iedere locatie is aangegeven wat het plaatsbare schaduwvrije zon-PV-vermogen is, uitgaande van schaduwvrije velden en 0,65 MWp vermogen per hectare grond.\n\nTevens is de verwachte jaarlijkse kWh-opbrengst aangeduid (900 kWh/kWp), evenals het aantal huishoudens dat van groene stroom kan worden voorzien met deze opbrengst (3.300 kWh/huishouden).\nDe selectie van locaties is expliciet niet gemaakt op basis van politieke voorkeuren of richtlijnen van gemeenten dan wel provincies, bijvoorbeeld met betrekking tot de (on)wenselijkheid van zonnevelden op landbouwgronden.\n\nToekomstige uitbreiding (1)\nGewerkt wordt aan een weergave van de kaartlaag met daarin relevante netdata verwerkt. Concreet gaat dit dan om de afstanden van denkbare locaties tot aan het middenspanningsnet of het dichtstbijzijnde onder-, regel- of schakelstation.\n\nToekomstige uitbreiding (2)\nTevens wordt gewerkt aan weergave van de kaartlaag met daarin zoninstralingsdata op de denkbare locaties voor zonnepanelen in veldopstelling. Hiermee wordt het schaduweffect van objecten op en rond het terrein inzichtelijk gemaakt.",
+        "providers": ["atlasleefomgeving@rivm.nl, Atlas Leefomgeving"],
+        "externalIds": [
+          {
+            "scheme": "default",
+            "value": "b7d2fd24-8cd8-4965-a997-69eb1a987b5a"
+          }
+        ],
+        "themes": [
+          {
+            "concepts": ["zonnepanelen", "energie"],
+            "scheme": null
+          }
+        ],
+        "extent": {
+          "spatial": {
+            "bbox": [[3.37087, 50.7539, 7.21097, 53.4658]],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "temporal": {
+            "interval": [null, null],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+          }
+        }
+      },
+      "links": [
+        {
+          "href": "http://geodata.rivm.nl/geoserver/nea/wms?",
+          "rel": "item",
+          "title": "Greenspread_20181101_v_zonnevelden",
+          "type": "OGC:WMS"
+        },
+        {
+          "href": "http://geodata.rivm.nl/geoserver/nea/wms?",
+          "rel": "item",
+          "title": "Greenspread_20181101_v_zonnevelden",
+          "type": "OGC:WFS"
+        }
+      ]
+    }
+  ],
+  "numberMatched": 308,
+  "numberReturned": 10,
+  "links": [
+    {
+      "type": "application/geo+json",
+      "rel": "self",
+      "title": "This document as GeoJSON",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata/items?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "application/ld+json",
+      "title": "This document as RDF (JSON-LD)",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata/items?f=jsonld"
+    },
+    {
+      "type": "text/html",
+      "rel": "alternate",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata/items?f=html"
+    },
+    {
+      "type": "application/geo+json",
+      "rel": "next",
+      "title": "items (next)",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata/items?offset=10"
+    },
+    {
+      "type": "application/json",
+      "title": "Sample metadata records from Dutch Nationaal georegister",
+      "rel": "collection",
+      "href": "https://my.server.org/sample-data/collections/dutch-metadata/items"
+    }
+  ],
+  "timeStamp": "2023-01-28T21:41:57.278222Z"
+}

--- a/fixtures/ogc-api/sample-data/collections/dutch-metadata/items/35149dfb-31d3-431c-a8bc-12a4034dac48.json
+++ b/fixtures/ogc-api/sample-data/collections/dutch-metadata/items/35149dfb-31d3-431c-a8bc-12a4034dac48.json
@@ -1,0 +1,114 @@
+{
+  "id": "35149dfb-31d3-431c-a8bc-12a4034dac48",
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [4.690751953125, 52.358740234375],
+        [4.690751953125, 52.6333984375],
+        [5.020341796875, 52.6333984375],
+        [5.020341796875, 52.358740234375],
+        [4.690751953125, 52.358740234375]
+      ]
+    ]
+  },
+  "properties": {
+    "recordCreated": "2021-12-08",
+    "recordUpdated": "2022-06-10T01:27:47Z",
+    "type": "dataset",
+    "title": "Kaartboeck 1635",
+    "description": "Data uit kaartboeken van de periode 1635 tot 1775. De kaartboeken werden door het waterschap gebruikt om er op toe te zien dat de eigenaren geen water in beslag namen door demping.\nDe percelen op de kaart zijn naar de huidige maatstaven vrij nauwkeurig gemeten en voorzien van een administratie met de eigenaren. bijzondere locaties van molens werven en beroepen worden in de boeken vermeld. Alle 97 kaarten aan een geven een zeer gedetailleerd beeld van de Voorzaan, Nieuwe Haven en de Achterzaan. De bladen Oost en West van de zaan zijn vrij nauwkeurig. De bladen aan de Voorzaan zijn een schetsmatige weergave van de situatie. De kaart van de Nieuwe Haven si weer nauwkeurig te noemen.",
+    "providers": ["Team Geo, geo-informatie@zaanstad.nl, Gemeente Zaanstad"],
+    "externalIds": [
+      {
+        "scheme": "default",
+        "value": "35149dfb-31d3-431c-a8bc-12a4034dac48"
+      }
+    ],
+    "themes": [
+      {
+        "concepts": [
+          "ARGEOLOGIE",
+          "MONUMENTEN",
+          "KADASTER",
+          "KAARTBOEK",
+          "KAARTBOECK",
+          "HISTORIE"
+        ]
+      }
+    ],
+    "extent": {
+      "spatial": {
+        "bbox": [
+          [4.690751953125, 52.358740234375, 5.020341796875, 52.6333984375]
+        ],
+        "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      },
+      "temporal": {
+        "interval": [null, null],
+        "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+      }
+    }
+  },
+  "links": [
+    {
+      "href": "https://maps-intern.zaanstad.gem.local/geoserver/wms?SERVICE=WMS",
+      "rel": "item",
+      "title": "geo:kaartboeck",
+      "type": "OGC:WMS"
+    },
+    {
+      "href": "https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS",
+      "rel": "item",
+      "title": "geo:kaartboeck",
+      "type": "OGC:WFS"
+    },
+    {
+      "href": "https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=geo:kaartboeck&outputFormat=csv",
+      "rel": "item",
+      "type": "download"
+    },
+    {
+      "href": "https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=geo:kaartboeck&outputFormat=shape-zip",
+      "rel": "item",
+      "type": "download"
+    },
+    {
+      "type": "application/json",
+      "rel": "root",
+      "title": "The landing page of this server as JSON",
+      "href": "https://demo.pygeoapi.io/master?f=json"
+    },
+    {
+      "type": "text/html",
+      "rel": "root",
+      "title": "The landing page of this server as HTML",
+      "href": "https://demo.pygeoapi.io/master?f=html"
+    },
+    {
+      "rel": "self",
+      "type": "application/geo+json",
+      "title": "This document as GeoJSON",
+      "href": "https://demo.pygeoapi.io/master/collections/dutch-metadata/items/35149dfb-31d3-431c-a8bc-12a4034dac48?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "application/ld+json",
+      "title": "This document as RDF (JSON-LD)",
+      "href": "https://demo.pygeoapi.io/master/collections/dutch-metadata/items/35149dfb-31d3-431c-a8bc-12a4034dac48?f=jsonld"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://demo.pygeoapi.io/master/collections/dutch-metadata/items/35149dfb-31d3-431c-a8bc-12a4034dac48?f=html"
+    },
+    {
+      "rel": "collection",
+      "type": "application/json",
+      "title": "Sample metadata records from Dutch Nationaal georegister",
+      "href": "https://demo.pygeoapi.io/master/collections/dutch-metadata"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/collections/dutch-metadata/queryables.json
+++ b/fixtures/ogc-api/sample-data/collections/dutch-metadata/queryables.json
@@ -1,0 +1,47 @@
+{
+  "type": "object",
+  "title": "Sample metadata records from Dutch Nationaal georegister",
+  "properties": {
+    "geometry": {
+      "$ref": "https://geojson.org/schema/Geometry.json"
+    },
+    "recordCreated": {
+      "title": "recordCreated",
+      "type": "string"
+    },
+    "recordUpdated": {
+      "title": "recordUpdated",
+      "type": "string"
+    },
+    "type": {
+      "title": "type",
+      "type": "string"
+    },
+    "title": {
+      "title": "title",
+      "type": "string"
+    },
+    "description": {
+      "title": "description",
+      "type": "string"
+    },
+    "providers": {
+      "title": "providers",
+      "type": "string"
+    },
+    "externalIds": {
+      "title": "externalIds",
+      "type": "string"
+    },
+    "themes": {
+      "title": "themes",
+      "type": "string"
+    },
+    "q": {
+      "title": "q",
+      "type": "string"
+    }
+  },
+  "$schema": "http://json-schema.org/draft/2019-09/schema",
+  "$id": "https://my.server.org/sample-data/collections/dutch-metadata/queryables"
+}

--- a/fixtures/ogc-api/sample-data/collections/roads_national.json
+++ b/fixtures/ogc-api/sample-data/collections/roads_national.json
@@ -1,0 +1,108 @@
+{
+  "title": "National Roads",
+  "description": "Lines representing the road network. A road is defined as a metalled way for vehicles.",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data/collections/roads_national?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/collections/roads_national?f=html"
+    },
+    {
+      "rel": "alternate",
+      "type": "application/xml",
+      "title": "This document as XML",
+      "href": "https://my.server.org/sample-data/collections/roads_national?f=xml"
+    },
+    {
+      "rel": "license",
+      "title": "Open Government Licence (OGL)",
+      "href": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+      "title": "Queryable attributes",
+      "href": "https://my.server.org/sample-data/collections/roads_national/queryables"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/sortables",
+      "title": "Sortable attributes",
+      "href": "https://my.server.org/sample-data/collections/roads_national/sortables"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/0.0/schema-item",
+      "title": "Schema of features in 'National Roads'",
+      "href": "https://my.server.org/sample-data/collections/roads_national/schemas/feature"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/0.0/schema-collection",
+      "title": "Schema of feature collections in 'National Roads'",
+      "href": "https://my.server.org/sample-data/collections/roads_national/schemas/collection"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/styles",
+      "title": "Styles to render the data in maps",
+      "href": "https://my.server.org/sample-data/collections/roads_national/styles"
+    },
+    {
+      "rel": "items",
+      "type": "application/vnd.ogc.fg+json",
+      "title": "Access the features in the collection 'National Roads' as JSON-FG",
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=jsonfg"
+    },
+    {
+      "rel": "items",
+      "type": "application/geo+json",
+      "title": "Access the features in the collection 'National Roads' as GeoJSON",
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=json"
+    },
+    {
+      "rel": "items",
+      "type": "application/flatgeobuf",
+      "title": "Access the features in the collection 'National Roads' as FlatGeobuf",
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=fgb"
+    },
+    {
+      "rel": "items",
+      "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+      "title": "Access the features in the collection 'National Roads' as JSON-FG (GeoJSON Compatibility Mode)",
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=jsonfgc"
+    },
+    {
+      "rel": "items",
+      "type": "text/html",
+      "title": "Access the features in the collection 'National Roads' as HTML",
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=html"
+    }
+  ],
+  "id": "roads_national",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -6.4956758012099645,
+          50.08021976237488,
+          2.383883951687144,
+          58.54688148276149
+        ]
+      ],
+      "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+    }
+  },
+  "itemType": "feature",
+  "crs": [
+    "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "http://www.opengis.net/def/crs/EPSG/0/27700",
+    "http://www.opengis.net/def/crs/EPSG/0/4258",
+    "http://www.opengis.net/def/crs/EPSG/0/4326",
+    "http://www.opengis.net/def/crs/EPSG/0/3857"
+  ],
+  "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+  "itemCount": 123905
+}

--- a/fixtures/ogc-api/sample-data/collections/roads_national/items.json
+++ b/fixtures/ogc-api/sample-data/collections/roads_national/items.json
@@ -1,0 +1,185 @@
+{
+  "type": "FeatureCollection",
+  "numberReturned": 10,
+  "timeStamp": "2023-01-08T12:25:44Z",
+  "features": [
+    {
+      "type": "Feature",
+      "id": 1,
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-3.7146553, 58.0895513],
+          [-3.7171409, 58.0885901]
+        ]
+      },
+      "properties": { "type": "Primary", "number": "A9", "level": 0 }
+    },
+    {
+      "type": "Feature",
+      "id": 2,
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-3.7461507, 58.0813773],
+          [-3.7469084, 58.0810599],
+          [-3.7506235, 58.0802469]
+        ]
+      },
+      "properties": { "type": "Primary", "number": "A9", "level": 0 }
+    },
+    {
+      "type": "Feature",
+      "id": 3,
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-3.7450719, 58.0818592],
+          [-3.7461507, 58.0813773]
+        ]
+      },
+      "properties": { "type": "Primary", "number": "A9", "level": 0 }
+    },
+    {
+      "type": "Feature",
+      "id": 4,
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-3.7380837, 58.0842815],
+          [-3.7401187, 58.08358],
+          [-3.7420469, 58.0831224],
+          [-3.7437685, 58.0826047],
+          [-3.7450719, 58.0818592]
+        ]
+      },
+      "properties": { "type": "Primary", "number": "A9", "level": 0 }
+    },
+    {
+      "type": "Feature",
+      "id": 5,
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-3.7373997, 58.0845154],
+          [-3.7380837, 58.0842815]
+        ]
+      },
+      "properties": { "type": "Primary", "number": "A9", "level": 0 }
+    },
+    {
+      "type": "Feature",
+      "id": 6,
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-3.7171409, 58.0885901],
+          [-3.7174653, 58.0884718],
+          [-3.7195617, 58.087902],
+          [-3.721399, 58.0875031],
+          [-3.7256251, 58.0868944],
+          [-3.7289353, 58.0862476],
+          [-3.7321928, 58.0859159],
+          [-3.7333858, 58.0856841],
+          [-3.7353467, 58.0851992],
+          [-3.7373997, 58.0845154]
+        ]
+      },
+      "properties": { "type": "Primary", "number": "A9", "level": 0 }
+    },
+    {
+      "type": "Feature",
+      "id": 7,
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-3.7638606, 58.0763091],
+          [-3.7704891, 58.0745642]
+        ]
+      },
+      "properties": { "type": "Primary", "number": "A9", "level": 0 }
+    },
+    {
+      "type": "Feature",
+      "id": 8,
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-3.7099634, 58.0917321],
+          [-3.71127, 58.0910318],
+          [-3.7127532, 58.0903683],
+          [-3.7146553, 58.0895513]
+        ]
+      },
+      "properties": { "type": "Primary", "number": "A9", "level": 0 }
+    },
+    {
+      "type": "Feature",
+      "id": 9,
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-3.7036866, 58.0950811],
+          [-3.7038614, 58.0950389],
+          [-3.7056711, 58.0945655],
+          [-3.7064724, 58.0942942],
+          [-3.7072678, 58.0938973],
+          [-3.707711, 58.0935859],
+          [-3.7088797, 58.0924832],
+          [-3.7099634, 58.0917321]
+        ]
+      },
+      "properties": { "type": "Primary", "number": "A9", "level": 0 }
+    },
+    {
+      "type": "Feature",
+      "id": 10,
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-3.7036866, 58.0950811],
+          [-3.7029109, 58.0952652]
+        ]
+      },
+      "properties": { "type": "Primary", "number": "A9", "level": 0 }
+    }
+  ],
+  "links": [
+    {
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=json",
+      "rel": "self",
+      "type": "application/geo+json",
+      "title": "This document"
+    },
+    {
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=jsonfgc",
+      "rel": "alternate",
+      "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+      "title": "This document as JSON-FG (GeoJSON Compatibility Mode)"
+    },
+    {
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=fgb",
+      "rel": "alternate",
+      "type": "application/flatgeobuf",
+      "title": "This document as FlatGeobuf"
+    },
+    {
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=html",
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML"
+    },
+    {
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=jsonfg",
+      "rel": "alternate",
+      "type": "application/vnd.ogc.fg+json",
+      "title": "This document as JSON-FG"
+    },
+    {
+      "href": "https://my.server.org/sample-data/collections/roads_national/items?f=json&offset=10",
+      "rel": "next",
+      "type": "application/geo+json",
+      "title": "Next page"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/collections/roads_national/queryables.json
+++ b/fixtures/ogc-api/sample-data/collections/roads_national/queryables.json
@@ -1,0 +1,31 @@
+{
+  "title": "National Roads",
+  "description": "Lines representing the road network. A road is defined as a metalled way for vehicles.",
+  "properties": {
+    "type": {
+      "title": "Type",
+      "type": "string",
+      "enum": ["Primary", "Motorway"]
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "number": {
+      "title": "Number",
+      "type": "string"
+    },
+    "level": {
+      "title": "Level",
+      "type": "integer",
+      "enum": [0, 1, 2]
+    },
+    "geom": {
+      "$ref": "https://geojson.org/schema/LineString.json"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://my.server.org/sample-data/collections/roads_national/queryables"
+}

--- a/fixtures/ogc-api/sample-data/collections/roads_national/schemas/collection.json
+++ b/fixtures/ogc-api/sample-data/collections/roads_national/schemas/collection.json
@@ -1,0 +1,57 @@
+{
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["FeatureCollection"]
+    },
+    "links": {
+      "items": {
+        "$ref": "#/$defs/Link"
+      },
+      "type": "array"
+    },
+    "timeStamp": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "numberMatched": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "numberReturned": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "features": {
+      "items": {
+        "$ref": "https://my.server.org/sample-data/collections/roads_national/schemas/feature"
+      },
+      "type": "array"
+    }
+  },
+  "type": "object",
+  "required": ["type", "features"],
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://my.server.org/sample-data/collections/roads_national/schemas/collection",
+  "$defs": {
+    "Link": {
+      "properties": {
+        "href": {
+          "format": "uri-reference",
+          "type": "string"
+        },
+        "rel": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": ["href"]
+    }
+  }
+}

--- a/fixtures/ogc-api/sample-data/collections/roads_national/schemas/feature.json
+++ b/fixtures/ogc-api/sample-data/collections/roads_national/schemas/feature.json
@@ -1,0 +1,97 @@
+{
+  "title": "National Roads",
+  "description": "Lines representing the road network. A road is defined as a metalled way for vehicles.",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["Feature"]
+    },
+    "links": {
+      "items": {
+        "$ref": "#/$defs/Link"
+      },
+      "type": "array"
+    },
+    "id": {
+      "type": "integer"
+    },
+    "geometry": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "title": "GeoJSON LineString",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["LineString"]
+            },
+            "coordinates": {
+              "items": {
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 2,
+                "maxItems": 3,
+                "type": "array"
+              },
+              "minItems": 2,
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "required": ["type", "coordinates"]
+        }
+      ]
+    },
+    "properties": {
+      "properties": {
+        "type": {
+          "title": "Type",
+          "type": "string",
+          "enum": ["Primary", "Motorway"]
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "number": {
+          "title": "Number",
+          "type": "string"
+        },
+        "level": {
+          "title": "Level",
+          "type": "integer",
+          "enum": [0, 1, 2]
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "required": ["type", "geometry", "properties"],
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://my.server.org/sample-data/collections/roads_national/schemas/feature",
+  "$defs": {
+    "Link": {
+      "properties": {
+        "href": {
+          "format": "uri-reference",
+          "type": "string"
+        },
+        "rel": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": ["href"]
+    }
+  }
+}

--- a/fixtures/ogc-api/sample-data/collections/roads_national/sortables.json
+++ b/fixtures/ogc-api/sample-data/collections/roads_national/sortables.json
@@ -1,0 +1,18 @@
+{
+  "title": "National Roads",
+  "description": "Lines representing the road network. A road is defined as a metalled way for vehicles.",
+  "properties": {
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "number": {
+      "title": "Number",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://my.server.org/sample-data/collections/roads_national/sortables"
+}

--- a/fixtures/ogc-api/sample-data/collections/roads_national/styles.json
+++ b/fixtures/ogc-api/sample-data/collections/roads_national/styles.json
@@ -1,0 +1,156 @@
+{
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data/collections/roads_national/styles?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/collections/roads_national/styles?f=html"
+    }
+  ],
+  "styles": [
+    {
+      "title": "Deuteranopia",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Deuteranopia?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Deuteranopia?f=sld10"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Deuteranopia/metadata"
+        }
+      ],
+      "id": "Deuteranopia"
+    },
+    {
+      "title": "Light",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Light?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Light?f=sld10"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Light/metadata"
+        }
+      ],
+      "id": "Light"
+    },
+    {
+      "title": "Night",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Night?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Night?f=sld10"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Night/metadata"
+        }
+      ],
+      "id": "Night"
+    },
+    {
+      "title": "Outdoor",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Outdoor?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Outdoor?f=sld10"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Outdoor/metadata"
+        }
+      ],
+      "id": "Outdoor"
+    },
+    {
+      "title": "Road",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Road?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Road?f=sld10"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Road/metadata"
+        }
+      ],
+      "id": "Road"
+    },
+    {
+      "title": "Tritanopia",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.qgis.qml",
+          "title": "Style in format 'QGIS'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Tritanopia?f=qml"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.ogc.sld+xml;version=1.0",
+          "title": "Style in format 'SLD 1.0'",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Tritanopia?f=sld10"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/collections/roads_national/styles/Tritanopia/metadata"
+        }
+      ],
+      "id": "Tritanopia"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/conformance.json
+++ b/fixtures/ogc-api/sample-data/conformance.json
@@ -1,0 +1,57 @@
+{
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data/conformance?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/conformance?f=html"
+    }
+  ],
+  "conformsTo": [
+    "http://www.opengis.net/spec/cql2/0.0/conf/advanced-comparison-operators",
+    "http://www.opengis.net/spec/cql2/0.0/conf/array-operators",
+    "http://www.opengis.net/spec/cql2/0.0/conf/basic-cql2",
+    "http://www.opengis.net/spec/cql2/0.0/conf/basic-spatial-operators",
+    "http://www.opengis.net/spec/cql2/0.0/conf/case-insensitive-comparison",
+    "http://www.opengis.net/spec/cql2/0.0/conf/cql2-json",
+    "http://www.opengis.net/spec/cql2/0.0/conf/cql2-text",
+    "http://www.opengis.net/spec/cql2/0.0/conf/property-property",
+    "http://www.opengis.net/spec/cql2/0.0/conf/spatial-operators",
+    "http://www.opengis.net/spec/cql2/0.0/conf/temporal-operators",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/html",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+    "http://www.opengis.net/spec/ogcapi-common-2/0.0/conf/collections",
+    "http://www.opengis.net/spec/ogcapi-common-2/0.0/conf/html",
+    "http://www.opengis.net/spec/ogcapi-common-2/0.0/conf/json",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
+    "http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs",
+    "http://www.opengis.net/spec/ogcapi-features-3/0.0/conf/features-filter",
+    "http://www.opengis.net/spec/ogcapi-features-3/0.0/conf/filter",
+    "http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/manage-styles",
+    "http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/mapbox-styles",
+    "http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/sld-10",
+    "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/dataset-tilesets",
+    "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt",
+    "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset",
+    "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list",
+    "http://www.opengis.net/spec/tms/2.0/conf/json-tilematrixset",
+    "http://www.opengis.net/spec/tms/2.0/conf/json-tilematrixsetlimits",
+    "http://www.opengis.net/spec/tms/2.0/conf/json-tilesetmetadata",
+    "http://www.opengis.net/spec/tms/2.0/conf/tilematrixset",
+    "http://www.opengis.net/spec/tms/2.0/conf/tilematrixsetlimits",
+    "http://www.opengis.net/spec/tms/2.0/conf/tilesetmetadata"
+  ]
+}

--- a/fixtures/ogc-api/sample-data/conformance.json
+++ b/fixtures/ogc-api/sample-data/conformance.json
@@ -52,6 +52,11 @@
     "http://www.opengis.net/spec/tms/2.0/conf/json-tilesetmetadata",
     "http://www.opengis.net/spec/tms/2.0/conf/tilematrixset",
     "http://www.opengis.net/spec/tms/2.0/conf/tilematrixsetlimits",
-    "http://www.opengis.net/spec/tms/2.0/conf/tilesetmetadata"
+    "http://www.opengis.net/spec/tms/2.0/conf/tilesetmetadata",
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/html",
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/json",
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/opensearch",
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/sorting"
   ]
 }

--- a/fixtures/ogc-api/sample-data/resources.json
+++ b/fixtures/ogc-api/sample-data/resources.json
@@ -1,0 +1,10388 @@
+{
+  "title": null,
+  "description": null,
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data/resources?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/resources?f=html"
+    }
+  ],
+  "resources": [
+    {
+      "id": "Airport.svg",
+      "link": {
+        "rel": "item",
+        "title": "Airport.svg",
+        "href": "https://my.server.org/sample-data/resources/Airport.svg"
+      }
+    },
+    {
+      "id": "LRTS-UG.svg",
+      "link": {
+        "rel": "item",
+        "title": "LRTS-UG.svg",
+        "href": "https://my.server.org/sample-data/resources/LRTS-UG.svg"
+      }
+    },
+    {
+      "id": "LRTS.svg",
+      "link": {
+        "rel": "item",
+        "title": "LRTS.svg",
+        "href": "https://my.server.org/sample-data/resources/LRTS.svg"
+      }
+    },
+    {
+      "id": "LayerOrderQML.PNG",
+      "link": {
+        "rel": "item",
+        "title": "LayerOrderQML.PNG",
+        "href": "https://my.server.org/sample-data/resources/LayerOrderQML.PNG"
+      }
+    },
+    {
+      "id": "LayerOrderSLD.PNG",
+      "link": {
+        "rel": "item",
+        "title": "LayerOrderSLD.PNG",
+        "href": "https://my.server.org/sample-data/resources/LayerOrderSLD.PNG"
+      }
+    },
+    {
+      "id": "Open Sans Regular__0-255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__0-255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__0-255.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__1024-1279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__1024-1279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__1024-1279.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__10240-10495.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__10240-10495.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__10240-10495.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__10496-10751.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__10496-10751.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__10496-10751.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__10752-11007.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__10752-11007.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__10752-11007.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__11008-11263.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__11008-11263.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__11008-11263.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__11264-11519.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__11264-11519.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__11264-11519.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__11520-11775.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__11520-11775.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__11520-11775.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__11776-12031.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__11776-12031.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__11776-12031.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__12032-12287.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__12032-12287.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__12032-12287.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__12288-12543.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__12288-12543.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__12288-12543.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__12544-12799.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__12544-12799.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__12544-12799.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__1280-1535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__1280-1535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__1280-1535.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__12800-13055.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__12800-13055.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__12800-13055.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__13056-13311.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__13056-13311.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__13056-13311.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__13312-13567.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__13312-13567.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__13312-13567.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__13568-13823.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__13568-13823.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__13568-13823.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__13824-14079.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__13824-14079.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__13824-14079.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__14080-14335.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__14080-14335.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__14080-14335.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__14336-14591.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__14336-14591.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__14336-14591.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__14592-14847.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__14592-14847.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__14592-14847.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__14848-15103.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__14848-15103.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__14848-15103.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__15104-15359.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__15104-15359.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__15104-15359.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__1536-1791.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__1536-1791.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__1536-1791.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__15360-15615.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__15360-15615.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__15360-15615.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__15616-15871.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__15616-15871.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__15616-15871.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__15872-16127.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__15872-16127.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__15872-16127.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__16128-16383.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__16128-16383.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__16128-16383.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__16384-16639.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__16384-16639.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__16384-16639.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__16640-16895.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__16640-16895.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__16640-16895.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__16896-17151.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__16896-17151.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__16896-17151.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__17152-17407.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__17152-17407.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__17152-17407.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__17408-17663.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__17408-17663.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__17408-17663.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__17664-17919.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__17664-17919.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__17664-17919.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__1792-2047.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__1792-2047.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__1792-2047.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__17920-18175.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__17920-18175.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__17920-18175.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__18176-18431.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__18176-18431.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__18176-18431.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__18432-18687.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__18432-18687.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__18432-18687.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__18688-18943.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__18688-18943.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__18688-18943.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__18944-19199.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__18944-19199.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__18944-19199.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__19200-19455.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__19200-19455.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__19200-19455.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__19456-19711.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__19456-19711.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__19456-19711.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__19712-19967.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__19712-19967.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__19712-19967.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__19968-20223.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__19968-20223.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__19968-20223.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__20224-20479.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__20224-20479.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__20224-20479.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__2048-2303.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__2048-2303.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__2048-2303.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__20480-20735.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__20480-20735.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__20480-20735.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__20736-20991.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__20736-20991.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__20736-20991.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__20992-21247.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__20992-21247.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__20992-21247.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__21248-21503.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__21248-21503.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__21248-21503.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__21504-21759.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__21504-21759.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__21504-21759.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__21760-22015.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__21760-22015.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__21760-22015.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__22016-22271.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__22016-22271.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__22016-22271.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__22272-22527.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__22272-22527.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__22272-22527.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__22528-22783.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__22528-22783.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__22528-22783.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__22784-23039.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__22784-23039.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__22784-23039.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__2304-2559.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__2304-2559.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__2304-2559.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__23040-23295.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__23040-23295.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__23040-23295.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__23296-23551.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__23296-23551.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__23296-23551.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__23552-23807.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__23552-23807.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__23552-23807.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__23808-24063.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__23808-24063.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__23808-24063.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__24064-24319.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__24064-24319.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__24064-24319.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__24320-24575.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__24320-24575.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__24320-24575.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__24576-24831.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__24576-24831.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__24576-24831.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__24832-25087.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__24832-25087.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__24832-25087.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__25088-25343.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__25088-25343.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__25088-25343.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__25344-25599.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__25344-25599.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__25344-25599.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__256-511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__256-511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__256-511.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__2560-2815.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__2560-2815.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__2560-2815.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__25600-25855.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__25600-25855.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__25600-25855.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__25856-26111.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__25856-26111.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__25856-26111.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__26112-26367.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__26112-26367.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__26112-26367.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__26368-26623.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__26368-26623.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__26368-26623.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__26624-26879.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__26624-26879.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__26624-26879.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__26880-27135.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__26880-27135.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__26880-27135.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__27136-27391.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__27136-27391.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__27136-27391.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__27392-27647.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__27392-27647.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__27392-27647.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__27648-27903.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__27648-27903.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__27648-27903.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__27904-28159.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__27904-28159.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__27904-28159.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__2816-3071.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__2816-3071.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__2816-3071.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__28160-28415.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__28160-28415.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__28160-28415.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__28416-28671.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__28416-28671.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__28416-28671.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__28672-28927.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__28672-28927.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__28672-28927.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__28928-29183.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__28928-29183.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__28928-29183.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__29184-29439.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__29184-29439.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__29184-29439.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__29440-29695.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__29440-29695.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__29440-29695.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__29696-29951.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__29696-29951.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__29696-29951.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__29952-30207.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__29952-30207.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__29952-30207.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__30208-30463.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__30208-30463.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__30208-30463.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__30464-30719.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__30464-30719.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__30464-30719.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__3072-3327.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__3072-3327.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__3072-3327.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__30720-30975.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__30720-30975.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__30720-30975.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__30976-31231.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__30976-31231.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__30976-31231.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__31232-31487.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__31232-31487.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__31232-31487.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__31488-31743.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__31488-31743.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__31488-31743.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__31744-31999.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__31744-31999.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__31744-31999.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__32000-32255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__32000-32255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__32000-32255.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__32256-32511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__32256-32511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__32256-32511.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__32512-32767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__32512-32767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__32512-32767.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__32768-33023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__32768-33023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__32768-33023.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__33024-33279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__33024-33279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__33024-33279.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__3328-3583.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__3328-3583.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__3328-3583.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__33280-33535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__33280-33535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__33280-33535.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__33536-33791.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__33536-33791.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__33536-33791.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__33792-34047.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__33792-34047.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__33792-34047.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__34048-34303.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__34048-34303.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__34048-34303.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__34304-34559.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__34304-34559.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__34304-34559.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__34560-34815.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__34560-34815.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__34560-34815.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__34816-35071.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__34816-35071.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__34816-35071.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__35072-35327.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__35072-35327.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__35072-35327.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__35328-35583.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__35328-35583.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__35328-35583.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__35584-35839.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__35584-35839.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__35584-35839.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__3584-3839.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__3584-3839.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__3584-3839.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__35840-36095.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__35840-36095.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__35840-36095.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__36096-36351.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__36096-36351.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__36096-36351.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__36352-36607.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__36352-36607.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__36352-36607.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__36608-36863.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__36608-36863.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__36608-36863.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__36864-37119.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__36864-37119.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__36864-37119.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__37120-37375.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__37120-37375.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__37120-37375.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__37376-37631.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__37376-37631.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__37376-37631.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__37632-37887.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__37632-37887.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__37632-37887.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__37888-38143.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__37888-38143.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__37888-38143.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__38144-38399.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__38144-38399.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__38144-38399.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__3840-4095.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__3840-4095.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__3840-4095.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__38400-38655.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__38400-38655.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__38400-38655.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__38656-38911.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__38656-38911.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__38656-38911.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__38912-39167.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__38912-39167.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__38912-39167.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__39168-39423.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__39168-39423.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__39168-39423.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__39424-39679.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__39424-39679.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__39424-39679.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__39680-39935.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__39680-39935.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__39680-39935.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__39936-40191.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__39936-40191.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__39936-40191.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__40192-40447.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__40192-40447.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__40192-40447.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__40448-40703.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__40448-40703.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__40448-40703.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__40704-40959.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__40704-40959.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__40704-40959.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__4096-4351.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__4096-4351.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__4096-4351.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__40960-41215.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__40960-41215.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__40960-41215.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__41216-41471.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__41216-41471.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__41216-41471.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__41472-41727.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__41472-41727.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__41472-41727.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__41728-41983.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__41728-41983.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__41728-41983.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__41984-42239.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__41984-42239.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__41984-42239.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__42240-42495.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__42240-42495.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__42240-42495.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__42496-42751.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__42496-42751.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__42496-42751.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__42752-43007.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__42752-43007.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__42752-43007.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__43008-43263.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__43008-43263.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__43008-43263.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__43264-43519.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__43264-43519.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__43264-43519.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__4352-4607.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__4352-4607.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__4352-4607.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__43520-43775.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__43520-43775.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__43520-43775.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__43776-44031.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__43776-44031.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__43776-44031.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__44032-44287.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__44032-44287.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__44032-44287.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__44288-44543.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__44288-44543.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__44288-44543.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__44544-44799.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__44544-44799.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__44544-44799.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__44800-45055.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__44800-45055.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__44800-45055.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__45056-45311.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__45056-45311.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__45056-45311.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__45312-45567.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__45312-45567.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__45312-45567.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__45568-45823.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__45568-45823.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__45568-45823.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__45824-46079.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__45824-46079.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__45824-46079.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__4608-4863.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__4608-4863.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__4608-4863.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__46080-46335.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__46080-46335.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__46080-46335.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__46336-46591.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__46336-46591.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__46336-46591.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__46592-46847.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__46592-46847.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__46592-46847.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__46848-47103.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__46848-47103.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__46848-47103.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__47104-47359.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__47104-47359.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__47104-47359.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__47360-47615.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__47360-47615.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__47360-47615.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__47616-47871.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__47616-47871.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__47616-47871.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__47872-48127.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__47872-48127.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__47872-48127.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__48128-48383.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__48128-48383.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__48128-48383.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__48384-48639.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__48384-48639.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__48384-48639.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__4864-5119.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__4864-5119.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__4864-5119.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__48640-48895.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__48640-48895.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__48640-48895.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__48896-49151.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__48896-49151.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__48896-49151.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__49152-49407.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__49152-49407.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__49152-49407.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__49408-49663.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__49408-49663.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__49408-49663.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__49664-49919.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__49664-49919.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__49664-49919.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__49920-50175.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__49920-50175.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__49920-50175.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__50176-50431.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__50176-50431.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__50176-50431.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__50432-50687.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__50432-50687.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__50432-50687.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__50688-50943.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__50688-50943.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__50688-50943.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__50944-51199.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__50944-51199.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__50944-51199.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__512-767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__512-767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__512-767.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__5120-5375.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__5120-5375.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__5120-5375.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__51200-51455.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__51200-51455.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__51200-51455.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__51456-51711.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__51456-51711.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__51456-51711.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__51712-51967.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__51712-51967.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__51712-51967.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__51968-52223.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__51968-52223.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__51968-52223.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__52224-52479.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__52224-52479.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__52224-52479.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__52480-52735.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__52480-52735.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__52480-52735.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__52736-52991.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__52736-52991.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__52736-52991.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__52992-53247.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__52992-53247.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__52992-53247.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__53248-53503.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__53248-53503.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__53248-53503.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__53504-53759.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__53504-53759.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__53504-53759.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__5376-5631.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__5376-5631.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__5376-5631.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__53760-54015.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__53760-54015.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__53760-54015.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__54016-54271.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__54016-54271.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__54016-54271.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__54272-54527.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__54272-54527.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__54272-54527.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__54528-54783.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__54528-54783.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__54528-54783.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__54784-55039.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__54784-55039.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__54784-55039.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__55040-55295.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__55040-55295.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__55040-55295.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__55296-55551.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__55296-55551.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__55296-55551.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__55552-55807.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__55552-55807.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__55552-55807.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__55808-56063.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__55808-56063.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__55808-56063.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__56064-56319.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__56064-56319.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__56064-56319.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__5632-5887.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__5632-5887.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__5632-5887.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__56320-56575.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__56320-56575.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__56320-56575.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__56576-56831.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__56576-56831.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__56576-56831.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__56832-57087.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__56832-57087.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__56832-57087.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__57088-57343.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__57088-57343.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__57088-57343.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__57344-57599.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__57344-57599.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__57344-57599.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__57600-57855.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__57600-57855.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__57600-57855.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__57856-58111.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__57856-58111.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__57856-58111.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__58112-58367.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__58112-58367.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__58112-58367.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__58368-58623.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__58368-58623.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__58368-58623.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__58624-58879.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__58624-58879.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__58624-58879.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__5888-6143.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__5888-6143.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__5888-6143.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__58880-59135.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__58880-59135.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__58880-59135.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__59136-59391.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__59136-59391.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__59136-59391.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__59392-59647.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__59392-59647.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__59392-59647.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__59648-59903.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__59648-59903.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__59648-59903.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__59904-60159.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__59904-60159.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__59904-60159.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__60160-60415.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__60160-60415.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__60160-60415.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__60416-60671.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__60416-60671.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__60416-60671.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__60672-60927.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__60672-60927.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__60672-60927.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__60928-61183.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__60928-61183.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__60928-61183.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__61184-61439.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__61184-61439.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__61184-61439.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__6144-6399.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__6144-6399.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__6144-6399.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__61440-61695.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__61440-61695.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__61440-61695.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__61696-61951.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__61696-61951.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__61696-61951.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__61952-62207.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__61952-62207.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__61952-62207.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__62208-62463.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__62208-62463.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__62208-62463.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__62464-62719.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__62464-62719.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__62464-62719.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__62720-62975.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__62720-62975.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__62720-62975.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__62976-63231.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__62976-63231.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__62976-63231.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__63232-63487.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__63232-63487.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__63232-63487.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__63488-63743.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__63488-63743.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__63488-63743.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__63744-63999.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__63744-63999.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__63744-63999.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__6400-6655.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__6400-6655.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__6400-6655.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__64000-64255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__64000-64255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__64000-64255.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__64256-64511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__64256-64511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__64256-64511.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__64512-64767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__64512-64767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__64512-64767.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__64768-65023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__64768-65023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__64768-65023.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__65024-65279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__65024-65279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__65024-65279.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__65280-65535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__65280-65535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__65280-65535.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__6656-6911.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__6656-6911.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__6656-6911.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__6912-7167.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__6912-7167.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__6912-7167.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__7168-7423.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__7168-7423.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__7168-7423.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__7424-7679.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__7424-7679.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__7424-7679.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__768-1023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__768-1023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__768-1023.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__7680-7935.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__7680-7935.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__7680-7935.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__7936-8191.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__7936-8191.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__7936-8191.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__8192-8447.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__8192-8447.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__8192-8447.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__8448-8703.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__8448-8703.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__8448-8703.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__8704-8959.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__8704-8959.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__8704-8959.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__8960-9215.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__8960-9215.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__8960-9215.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__9216-9471.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__9216-9471.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__9216-9471.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__9472-9727.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__9472-9727.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__9472-9727.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__9728-9983.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__9728-9983.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__9728-9983.pbf"
+      }
+    },
+    {
+      "id": "Open Sans Regular__9984-10239.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Open Sans Regular__9984-10239.pbf",
+        "href": "https://my.server.org/sample-data/resources/Open%20Sans%20Regular__9984-10239.pbf"
+      }
+    },
+    {
+      "id": "RS-LRTS.svg",
+      "link": {
+        "rel": "item",
+        "title": "RS-LRTS.svg",
+        "href": "https://my.server.org/sample-data/resources/RS-LRTS.svg"
+      }
+    },
+    {
+      "id": "RS-UG.svg",
+      "link": {
+        "rel": "item",
+        "title": "RS-UG.svg",
+        "href": "https://my.server.org/sample-data/resources/RS-UG.svg"
+      }
+    },
+    {
+      "id": "RS.svg",
+      "link": {
+        "rel": "item",
+        "title": "RS.svg",
+        "href": "https://my.server.org/sample-data/resources/RS.svg"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__0-255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__0-255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__0-255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__1024-1279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__1024-1279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__1024-1279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__10240-10495.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__10240-10495.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__10240-10495.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__10496-10751.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__10496-10751.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__10496-10751.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__10752-11007.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__10752-11007.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__10752-11007.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__11008-11263.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__11008-11263.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__11008-11263.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__11264-11519.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__11264-11519.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__11264-11519.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__11520-11775.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__11520-11775.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__11520-11775.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__11776-12031.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__11776-12031.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__11776-12031.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__12032-12287.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__12032-12287.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__12032-12287.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__12288-12543.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__12288-12543.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__12288-12543.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__12544-12799.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__12544-12799.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__12544-12799.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__1280-1535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__1280-1535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__1280-1535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__12800-13055.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__12800-13055.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__12800-13055.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__13056-13311.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__13056-13311.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__13056-13311.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__13312-13567.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__13312-13567.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__13312-13567.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__13568-13823.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__13568-13823.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__13568-13823.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__13824-14079.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__13824-14079.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__13824-14079.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__14080-14335.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__14080-14335.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__14080-14335.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__14336-14591.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__14336-14591.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__14336-14591.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__14592-14847.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__14592-14847.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__14592-14847.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__14848-15103.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__14848-15103.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__14848-15103.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__15104-15359.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__15104-15359.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__15104-15359.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__1536-1791.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__1536-1791.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__1536-1791.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__15360-15615.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__15360-15615.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__15360-15615.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__15616-15871.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__15616-15871.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__15616-15871.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__15872-16127.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__15872-16127.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__15872-16127.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__16128-16383.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__16128-16383.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__16128-16383.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__16384-16639.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__16384-16639.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__16384-16639.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__16640-16895.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__16640-16895.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__16640-16895.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__16896-17151.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__16896-17151.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__16896-17151.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__17152-17407.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__17152-17407.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__17152-17407.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__17408-17663.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__17408-17663.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__17408-17663.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__17664-17919.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__17664-17919.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__17664-17919.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__1792-2047.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__1792-2047.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__1792-2047.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__17920-18175.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__17920-18175.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__17920-18175.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__18176-18431.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__18176-18431.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__18176-18431.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__18432-18687.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__18432-18687.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__18432-18687.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__18688-18943.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__18688-18943.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__18688-18943.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__18944-19199.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__18944-19199.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__18944-19199.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__19200-19455.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__19200-19455.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__19200-19455.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__19456-19711.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__19456-19711.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__19456-19711.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__19712-19967.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__19712-19967.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__19712-19967.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__19968-20223.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__19968-20223.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__19968-20223.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__20224-20479.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__20224-20479.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__20224-20479.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__2048-2303.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__2048-2303.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__2048-2303.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__20480-20735.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__20480-20735.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__20480-20735.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__20736-20991.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__20736-20991.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__20736-20991.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__20992-21247.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__20992-21247.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__20992-21247.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__21248-21503.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__21248-21503.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__21248-21503.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__21504-21759.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__21504-21759.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__21504-21759.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__21760-22015.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__21760-22015.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__21760-22015.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__22016-22271.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__22016-22271.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__22016-22271.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__22272-22527.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__22272-22527.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__22272-22527.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__22528-22783.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__22528-22783.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__22528-22783.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__22784-23039.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__22784-23039.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__22784-23039.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__2304-2559.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__2304-2559.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__2304-2559.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__23040-23295.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__23040-23295.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__23040-23295.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__23296-23551.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__23296-23551.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__23296-23551.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__23552-23807.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__23552-23807.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__23552-23807.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__23808-24063.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__23808-24063.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__23808-24063.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__24064-24319.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__24064-24319.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__24064-24319.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__24320-24575.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__24320-24575.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__24320-24575.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__24576-24831.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__24576-24831.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__24576-24831.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__24832-25087.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__24832-25087.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__24832-25087.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__25088-25343.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__25088-25343.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__25088-25343.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__25344-25599.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__25344-25599.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__25344-25599.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__256-511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__256-511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__256-511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__2560-2815.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__2560-2815.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__2560-2815.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__25600-25855.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__25600-25855.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__25600-25855.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__25856-26111.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__25856-26111.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__25856-26111.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__26112-26367.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__26112-26367.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__26112-26367.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__26368-26623.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__26368-26623.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__26368-26623.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__26624-26879.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__26624-26879.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__26624-26879.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__26880-27135.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__26880-27135.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__26880-27135.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__27136-27391.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__27136-27391.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__27136-27391.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__27392-27647.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__27392-27647.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__27392-27647.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__27648-27903.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__27648-27903.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__27648-27903.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__27904-28159.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__27904-28159.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__27904-28159.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__2816-3071.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__2816-3071.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__2816-3071.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__28160-28415.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__28160-28415.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__28160-28415.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__28416-28671.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__28416-28671.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__28416-28671.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__28672-28927.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__28672-28927.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__28672-28927.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__28928-29183.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__28928-29183.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__28928-29183.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__29184-29439.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__29184-29439.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__29184-29439.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__29440-29695.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__29440-29695.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__29440-29695.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__29696-29951.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__29696-29951.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__29696-29951.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__29952-30207.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__29952-30207.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__29952-30207.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__30208-30463.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__30208-30463.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__30208-30463.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__30464-30719.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__30464-30719.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__30464-30719.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__3072-3327.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__3072-3327.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__3072-3327.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__30720-30975.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__30720-30975.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__30720-30975.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__30976-31231.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__30976-31231.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__30976-31231.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__31232-31487.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__31232-31487.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__31232-31487.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__31488-31743.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__31488-31743.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__31488-31743.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__31744-31999.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__31744-31999.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__31744-31999.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__32000-32255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__32000-32255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__32000-32255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__32256-32511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__32256-32511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__32256-32511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__32512-32767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__32512-32767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__32512-32767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__32768-33023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__32768-33023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__32768-33023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__33024-33279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__33024-33279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__33024-33279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__3328-3583.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__3328-3583.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__3328-3583.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__33280-33535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__33280-33535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__33280-33535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__33536-33791.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__33536-33791.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__33536-33791.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__33792-34047.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__33792-34047.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__33792-34047.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__34048-34303.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__34048-34303.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__34048-34303.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__34304-34559.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__34304-34559.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__34304-34559.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__34560-34815.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__34560-34815.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__34560-34815.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__34816-35071.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__34816-35071.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__34816-35071.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__35072-35327.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__35072-35327.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__35072-35327.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__35328-35583.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__35328-35583.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__35328-35583.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__35584-35839.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__35584-35839.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__35584-35839.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__3584-3839.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__3584-3839.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__3584-3839.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__35840-36095.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__35840-36095.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__35840-36095.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__36096-36351.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__36096-36351.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__36096-36351.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__36352-36607.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__36352-36607.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__36352-36607.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__36608-36863.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__36608-36863.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__36608-36863.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__36864-37119.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__36864-37119.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__36864-37119.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__37120-37375.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__37120-37375.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__37120-37375.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__37376-37631.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__37376-37631.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__37376-37631.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__37632-37887.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__37632-37887.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__37632-37887.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__37888-38143.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__37888-38143.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__37888-38143.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__38144-38399.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__38144-38399.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__38144-38399.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__3840-4095.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__3840-4095.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__3840-4095.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__38400-38655.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__38400-38655.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__38400-38655.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__38656-38911.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__38656-38911.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__38656-38911.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__38912-39167.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__38912-39167.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__38912-39167.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__39168-39423.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__39168-39423.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__39168-39423.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__39424-39679.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__39424-39679.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__39424-39679.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__39680-39935.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__39680-39935.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__39680-39935.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__39936-40191.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__39936-40191.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__39936-40191.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__40192-40447.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__40192-40447.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__40192-40447.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__40448-40703.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__40448-40703.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__40448-40703.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__40704-40959.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__40704-40959.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__40704-40959.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__4096-4351.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__4096-4351.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__4096-4351.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__40960-41215.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__40960-41215.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__40960-41215.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__41216-41471.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__41216-41471.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__41216-41471.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__41472-41727.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__41472-41727.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__41472-41727.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__41728-41983.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__41728-41983.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__41728-41983.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__41984-42239.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__41984-42239.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__41984-42239.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__42240-42495.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__42240-42495.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__42240-42495.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__42496-42751.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__42496-42751.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__42496-42751.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__42752-43007.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__42752-43007.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__42752-43007.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__43008-43263.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__43008-43263.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__43008-43263.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__43264-43519.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__43264-43519.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__43264-43519.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__4352-4607.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__4352-4607.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__4352-4607.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__43520-43775.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__43520-43775.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__43520-43775.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__43776-44031.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__43776-44031.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__43776-44031.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__44032-44287.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__44032-44287.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__44032-44287.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__44288-44543.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__44288-44543.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__44288-44543.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__44544-44799.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__44544-44799.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__44544-44799.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__44800-45055.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__44800-45055.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__44800-45055.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__45056-45311.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__45056-45311.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__45056-45311.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__45312-45567.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__45312-45567.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__45312-45567.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__45568-45823.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__45568-45823.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__45568-45823.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__45824-46079.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__45824-46079.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__45824-46079.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__4608-4863.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__4608-4863.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__4608-4863.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__46080-46335.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__46080-46335.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__46080-46335.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__46336-46591.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__46336-46591.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__46336-46591.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__46592-46847.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__46592-46847.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__46592-46847.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__46848-47103.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__46848-47103.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__46848-47103.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__47104-47359.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__47104-47359.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__47104-47359.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__47360-47615.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__47360-47615.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__47360-47615.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__47616-47871.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__47616-47871.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__47616-47871.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__47872-48127.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__47872-48127.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__47872-48127.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__48128-48383.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__48128-48383.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__48128-48383.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__48384-48639.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__48384-48639.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__48384-48639.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__4864-5119.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__4864-5119.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__4864-5119.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__48640-48895.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__48640-48895.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__48640-48895.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__48896-49151.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__48896-49151.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__48896-49151.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__49152-49407.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__49152-49407.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__49152-49407.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__49408-49663.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__49408-49663.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__49408-49663.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__49664-49919.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__49664-49919.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__49664-49919.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__49920-50175.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__49920-50175.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__49920-50175.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__50176-50431.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__50176-50431.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__50176-50431.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__50432-50687.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__50432-50687.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__50432-50687.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__50688-50943.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__50688-50943.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__50688-50943.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__50944-51199.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__50944-51199.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__50944-51199.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__512-767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__512-767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__512-767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__5120-5375.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__5120-5375.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__5120-5375.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__51200-51455.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__51200-51455.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__51200-51455.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__51456-51711.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__51456-51711.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__51456-51711.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__51712-51967.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__51712-51967.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__51712-51967.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__51968-52223.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__51968-52223.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__51968-52223.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__52224-52479.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__52224-52479.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__52224-52479.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__52480-52735.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__52480-52735.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__52480-52735.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__52736-52991.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__52736-52991.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__52736-52991.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__52992-53247.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__52992-53247.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__52992-53247.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__53248-53503.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__53248-53503.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__53248-53503.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__53504-53759.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__53504-53759.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__53504-53759.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__5376-5631.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__5376-5631.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__5376-5631.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__53760-54015.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__53760-54015.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__53760-54015.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__54016-54271.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__54016-54271.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__54016-54271.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__54272-54527.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__54272-54527.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__54272-54527.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__54528-54783.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__54528-54783.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__54528-54783.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__54784-55039.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__54784-55039.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__54784-55039.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__55040-55295.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__55040-55295.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__55040-55295.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__55296-55551.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__55296-55551.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__55296-55551.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__55552-55807.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__55552-55807.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__55552-55807.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__55808-56063.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__55808-56063.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__55808-56063.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__56064-56319.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__56064-56319.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__56064-56319.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__5632-5887.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__5632-5887.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__5632-5887.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__56320-56575.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__56320-56575.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__56320-56575.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__56576-56831.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__56576-56831.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__56576-56831.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__56832-57087.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__56832-57087.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__56832-57087.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__57088-57343.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__57088-57343.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__57088-57343.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__57344-57599.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__57344-57599.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__57344-57599.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__57600-57855.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__57600-57855.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__57600-57855.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__57856-58111.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__57856-58111.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__57856-58111.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__58112-58367.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__58112-58367.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__58112-58367.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__58368-58623.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__58368-58623.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__58368-58623.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__58624-58879.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__58624-58879.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__58624-58879.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__5888-6143.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__5888-6143.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__5888-6143.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__58880-59135.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__58880-59135.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__58880-59135.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__59136-59391.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__59136-59391.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__59136-59391.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__59392-59647.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__59392-59647.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__59392-59647.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__59648-59903.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__59648-59903.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__59648-59903.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__59904-60159.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__59904-60159.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__59904-60159.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__60160-60415.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__60160-60415.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__60160-60415.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__60416-60671.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__60416-60671.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__60416-60671.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__60672-60927.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__60672-60927.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__60672-60927.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__60928-61183.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__60928-61183.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__60928-61183.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__61184-61439.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__61184-61439.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__61184-61439.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__6144-6399.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__6144-6399.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__6144-6399.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__61440-61695.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__61440-61695.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__61440-61695.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__61696-61951.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__61696-61951.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__61696-61951.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__61952-62207.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__61952-62207.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__61952-62207.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__62208-62463.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__62208-62463.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__62208-62463.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__62464-62719.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__62464-62719.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__62464-62719.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__62720-62975.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__62720-62975.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__62720-62975.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__62976-63231.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__62976-63231.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__62976-63231.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__63232-63487.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__63232-63487.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__63232-63487.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__63488-63743.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__63488-63743.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__63488-63743.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__63744-63999.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__63744-63999.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__63744-63999.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__6400-6655.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__6400-6655.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__6400-6655.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__64000-64255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__64000-64255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__64000-64255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__64256-64511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__64256-64511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__64256-64511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__64512-64767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__64512-64767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__64512-64767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__64768-65023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__64768-65023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__64768-65023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__65024-65279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__65024-65279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__65024-65279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__65280-65535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__65280-65535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__65280-65535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__6656-6911.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__6656-6911.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__6656-6911.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__6912-7167.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__6912-7167.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__6912-7167.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__7168-7423.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__7168-7423.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__7168-7423.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__7424-7679.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__7424-7679.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__7424-7679.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__768-1023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__768-1023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__768-1023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__7680-7935.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__7680-7935.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__7680-7935.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__7936-8191.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__7936-8191.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__7936-8191.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__8192-8447.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__8192-8447.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__8192-8447.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__8448-8703.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__8448-8703.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__8448-8703.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__8704-8959.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__8704-8959.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__8704-8959.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__8960-9215.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__8960-9215.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__8960-9215.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__9216-9471.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__9216-9471.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__9216-9471.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__9472-9727.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__9472-9727.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__9472-9727.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__9728-9983.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__9728-9983.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__9728-9983.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Bold__9984-10239.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Bold__9984-10239.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Bold__9984-10239.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__0-255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__0-255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__0-255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__1024-1279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__1024-1279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__1024-1279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__10240-10495.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__10240-10495.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__10240-10495.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__10496-10751.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__10496-10751.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__10496-10751.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__10752-11007.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__10752-11007.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__10752-11007.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__11008-11263.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__11008-11263.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__11008-11263.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__11264-11519.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__11264-11519.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__11264-11519.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__11520-11775.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__11520-11775.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__11520-11775.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__11776-12031.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__11776-12031.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__11776-12031.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__12032-12287.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__12032-12287.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__12032-12287.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__12288-12543.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__12288-12543.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__12288-12543.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__12544-12799.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__12544-12799.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__12544-12799.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__1280-1535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__1280-1535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__1280-1535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__12800-13055.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__12800-13055.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__12800-13055.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__13056-13311.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__13056-13311.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__13056-13311.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__13312-13567.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__13312-13567.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__13312-13567.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__13568-13823.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__13568-13823.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__13568-13823.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__13824-14079.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__13824-14079.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__13824-14079.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__14080-14335.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__14080-14335.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__14080-14335.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__14336-14591.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__14336-14591.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__14336-14591.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__14592-14847.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__14592-14847.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__14592-14847.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__14848-15103.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__14848-15103.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__14848-15103.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__15104-15359.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__15104-15359.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__15104-15359.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__1536-1791.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__1536-1791.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__1536-1791.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__15360-15615.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__15360-15615.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__15360-15615.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__15616-15871.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__15616-15871.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__15616-15871.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__15872-16127.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__15872-16127.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__15872-16127.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__16128-16383.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__16128-16383.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__16128-16383.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__16384-16639.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__16384-16639.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__16384-16639.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__16640-16895.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__16640-16895.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__16640-16895.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__16896-17151.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__16896-17151.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__16896-17151.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__17152-17407.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__17152-17407.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__17152-17407.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__17408-17663.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__17408-17663.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__17408-17663.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__17664-17919.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__17664-17919.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__17664-17919.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__1792-2047.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__1792-2047.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__1792-2047.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__17920-18175.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__17920-18175.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__17920-18175.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__18176-18431.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__18176-18431.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__18176-18431.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__18432-18687.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__18432-18687.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__18432-18687.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__18688-18943.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__18688-18943.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__18688-18943.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__18944-19199.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__18944-19199.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__18944-19199.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__19200-19455.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__19200-19455.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__19200-19455.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__19456-19711.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__19456-19711.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__19456-19711.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__19712-19967.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__19712-19967.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__19712-19967.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__19968-20223.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__19968-20223.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__19968-20223.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__20224-20479.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__20224-20479.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__20224-20479.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__2048-2303.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__2048-2303.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__2048-2303.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__20480-20735.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__20480-20735.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__20480-20735.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__20736-20991.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__20736-20991.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__20736-20991.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__20992-21247.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__20992-21247.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__20992-21247.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__21248-21503.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__21248-21503.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__21248-21503.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__21504-21759.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__21504-21759.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__21504-21759.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__21760-22015.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__21760-22015.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__21760-22015.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__22016-22271.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__22016-22271.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__22016-22271.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__22272-22527.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__22272-22527.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__22272-22527.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__22528-22783.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__22528-22783.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__22528-22783.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__22784-23039.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__22784-23039.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__22784-23039.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__2304-2559.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__2304-2559.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__2304-2559.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__23040-23295.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__23040-23295.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__23040-23295.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__23296-23551.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__23296-23551.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__23296-23551.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__23552-23807.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__23552-23807.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__23552-23807.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__23808-24063.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__23808-24063.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__23808-24063.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__24064-24319.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__24064-24319.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__24064-24319.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__24320-24575.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__24320-24575.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__24320-24575.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__24576-24831.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__24576-24831.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__24576-24831.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__24832-25087.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__24832-25087.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__24832-25087.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__25088-25343.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__25088-25343.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__25088-25343.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__25344-25599.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__25344-25599.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__25344-25599.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__256-511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__256-511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__256-511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__2560-2815.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__2560-2815.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__2560-2815.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__25600-25855.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__25600-25855.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__25600-25855.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__25856-26111.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__25856-26111.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__25856-26111.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__26112-26367.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__26112-26367.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__26112-26367.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__26368-26623.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__26368-26623.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__26368-26623.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__26624-26879.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__26624-26879.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__26624-26879.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__26880-27135.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__26880-27135.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__26880-27135.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__27136-27391.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__27136-27391.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__27136-27391.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__27392-27647.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__27392-27647.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__27392-27647.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__27648-27903.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__27648-27903.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__27648-27903.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__27904-28159.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__27904-28159.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__27904-28159.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__2816-3071.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__2816-3071.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__2816-3071.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__28160-28415.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__28160-28415.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__28160-28415.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__28416-28671.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__28416-28671.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__28416-28671.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__28672-28927.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__28672-28927.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__28672-28927.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__28928-29183.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__28928-29183.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__28928-29183.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__29184-29439.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__29184-29439.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__29184-29439.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__29440-29695.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__29440-29695.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__29440-29695.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__29696-29951.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__29696-29951.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__29696-29951.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__29952-30207.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__29952-30207.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__29952-30207.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__30208-30463.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__30208-30463.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__30208-30463.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__30464-30719.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__30464-30719.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__30464-30719.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__3072-3327.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__3072-3327.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__3072-3327.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__30720-30975.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__30720-30975.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__30720-30975.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__30976-31231.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__30976-31231.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__30976-31231.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__31232-31487.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__31232-31487.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__31232-31487.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__31488-31743.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__31488-31743.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__31488-31743.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__31744-31999.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__31744-31999.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__31744-31999.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__32000-32255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__32000-32255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__32000-32255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__32256-32511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__32256-32511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__32256-32511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__32512-32767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__32512-32767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__32512-32767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__32768-33023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__32768-33023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__32768-33023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__33024-33279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__33024-33279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__33024-33279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__3328-3583.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__3328-3583.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__3328-3583.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__33280-33535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__33280-33535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__33280-33535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__33536-33791.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__33536-33791.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__33536-33791.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__33792-34047.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__33792-34047.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__33792-34047.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__34048-34303.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__34048-34303.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__34048-34303.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__34304-34559.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__34304-34559.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__34304-34559.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__34560-34815.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__34560-34815.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__34560-34815.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__34816-35071.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__34816-35071.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__34816-35071.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__35072-35327.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__35072-35327.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__35072-35327.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__35328-35583.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__35328-35583.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__35328-35583.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__35584-35839.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__35584-35839.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__35584-35839.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__3584-3839.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__3584-3839.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__3584-3839.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__35840-36095.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__35840-36095.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__35840-36095.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__36096-36351.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__36096-36351.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__36096-36351.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__36352-36607.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__36352-36607.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__36352-36607.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__36608-36863.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__36608-36863.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__36608-36863.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__36864-37119.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__36864-37119.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__36864-37119.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__37120-37375.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__37120-37375.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__37120-37375.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__37376-37631.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__37376-37631.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__37376-37631.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__37632-37887.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__37632-37887.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__37632-37887.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__37888-38143.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__37888-38143.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__37888-38143.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__38144-38399.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__38144-38399.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__38144-38399.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__3840-4095.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__3840-4095.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__3840-4095.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__38400-38655.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__38400-38655.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__38400-38655.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__38656-38911.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__38656-38911.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__38656-38911.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__38912-39167.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__38912-39167.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__38912-39167.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__39168-39423.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__39168-39423.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__39168-39423.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__39424-39679.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__39424-39679.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__39424-39679.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__39680-39935.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__39680-39935.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__39680-39935.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__39936-40191.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__39936-40191.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__39936-40191.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__40192-40447.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__40192-40447.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__40192-40447.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__40448-40703.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__40448-40703.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__40448-40703.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__40704-40959.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__40704-40959.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__40704-40959.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__4096-4351.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__4096-4351.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__4096-4351.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__40960-41215.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__40960-41215.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__40960-41215.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__41216-41471.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__41216-41471.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__41216-41471.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__41472-41727.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__41472-41727.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__41472-41727.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__41728-41983.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__41728-41983.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__41728-41983.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__41984-42239.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__41984-42239.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__41984-42239.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__42240-42495.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__42240-42495.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__42240-42495.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__42496-42751.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__42496-42751.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__42496-42751.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__42752-43007.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__42752-43007.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__42752-43007.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__43008-43263.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__43008-43263.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__43008-43263.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__43264-43519.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__43264-43519.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__43264-43519.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__4352-4607.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__4352-4607.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__4352-4607.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__43520-43775.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__43520-43775.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__43520-43775.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__43776-44031.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__43776-44031.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__43776-44031.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__44032-44287.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__44032-44287.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__44032-44287.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__44288-44543.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__44288-44543.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__44288-44543.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__44544-44799.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__44544-44799.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__44544-44799.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__44800-45055.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__44800-45055.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__44800-45055.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__45056-45311.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__45056-45311.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__45056-45311.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__45312-45567.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__45312-45567.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__45312-45567.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__45568-45823.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__45568-45823.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__45568-45823.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__45824-46079.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__45824-46079.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__45824-46079.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__4608-4863.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__4608-4863.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__4608-4863.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__46080-46335.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__46080-46335.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__46080-46335.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__46336-46591.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__46336-46591.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__46336-46591.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__46592-46847.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__46592-46847.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__46592-46847.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__46848-47103.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__46848-47103.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__46848-47103.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__47104-47359.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__47104-47359.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__47104-47359.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__47360-47615.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__47360-47615.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__47360-47615.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__47616-47871.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__47616-47871.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__47616-47871.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__47872-48127.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__47872-48127.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__47872-48127.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__48128-48383.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__48128-48383.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__48128-48383.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__48384-48639.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__48384-48639.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__48384-48639.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__4864-5119.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__4864-5119.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__4864-5119.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__48640-48895.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__48640-48895.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__48640-48895.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__48896-49151.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__48896-49151.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__48896-49151.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__49152-49407.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__49152-49407.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__49152-49407.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__49408-49663.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__49408-49663.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__49408-49663.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__49664-49919.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__49664-49919.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__49664-49919.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__49920-50175.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__49920-50175.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__49920-50175.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__50176-50431.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__50176-50431.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__50176-50431.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__50432-50687.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__50432-50687.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__50432-50687.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__50688-50943.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__50688-50943.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__50688-50943.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__50944-51199.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__50944-51199.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__50944-51199.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__512-767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__512-767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__512-767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__5120-5375.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__5120-5375.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__5120-5375.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__51200-51455.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__51200-51455.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__51200-51455.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__51456-51711.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__51456-51711.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__51456-51711.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__51712-51967.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__51712-51967.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__51712-51967.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__51968-52223.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__51968-52223.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__51968-52223.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__52224-52479.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__52224-52479.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__52224-52479.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__52480-52735.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__52480-52735.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__52480-52735.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__52736-52991.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__52736-52991.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__52736-52991.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__52992-53247.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__52992-53247.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__52992-53247.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__53248-53503.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__53248-53503.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__53248-53503.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__53504-53759.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__53504-53759.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__53504-53759.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__5376-5631.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__5376-5631.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__5376-5631.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__53760-54015.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__53760-54015.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__53760-54015.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__54016-54271.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__54016-54271.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__54016-54271.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__54272-54527.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__54272-54527.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__54272-54527.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__54528-54783.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__54528-54783.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__54528-54783.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__54784-55039.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__54784-55039.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__54784-55039.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__55040-55295.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__55040-55295.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__55040-55295.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__55296-55551.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__55296-55551.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__55296-55551.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__55552-55807.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__55552-55807.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__55552-55807.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__55808-56063.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__55808-56063.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__55808-56063.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__56064-56319.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__56064-56319.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__56064-56319.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__5632-5887.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__5632-5887.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__5632-5887.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__56320-56575.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__56320-56575.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__56320-56575.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__56576-56831.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__56576-56831.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__56576-56831.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__56832-57087.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__56832-57087.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__56832-57087.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__57088-57343.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__57088-57343.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__57088-57343.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__57344-57599.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__57344-57599.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__57344-57599.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__57600-57855.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__57600-57855.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__57600-57855.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__57856-58111.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__57856-58111.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__57856-58111.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__58112-58367.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__58112-58367.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__58112-58367.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__58368-58623.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__58368-58623.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__58368-58623.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__58624-58879.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__58624-58879.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__58624-58879.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__5888-6143.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__5888-6143.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__5888-6143.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__58880-59135.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__58880-59135.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__58880-59135.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__59136-59391.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__59136-59391.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__59136-59391.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__59392-59647.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__59392-59647.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__59392-59647.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__59648-59903.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__59648-59903.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__59648-59903.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__59904-60159.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__59904-60159.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__59904-60159.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__60160-60415.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__60160-60415.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__60160-60415.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__60416-60671.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__60416-60671.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__60416-60671.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__60672-60927.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__60672-60927.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__60672-60927.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__60928-61183.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__60928-61183.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__60928-61183.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__61184-61439.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__61184-61439.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__61184-61439.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__6144-6399.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__6144-6399.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__6144-6399.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__61440-61695.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__61440-61695.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__61440-61695.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__61696-61951.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__61696-61951.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__61696-61951.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__61952-62207.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__61952-62207.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__61952-62207.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__62208-62463.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__62208-62463.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__62208-62463.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__62464-62719.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__62464-62719.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__62464-62719.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__62720-62975.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__62720-62975.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__62720-62975.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__62976-63231.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__62976-63231.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__62976-63231.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__63232-63487.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__63232-63487.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__63232-63487.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__63488-63743.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__63488-63743.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__63488-63743.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__63744-63999.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__63744-63999.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__63744-63999.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__6400-6655.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__6400-6655.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__6400-6655.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__64000-64255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__64000-64255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__64000-64255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__64256-64511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__64256-64511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__64256-64511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__64512-64767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__64512-64767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__64512-64767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__64768-65023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__64768-65023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__64768-65023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__65024-65279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__65024-65279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__65024-65279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__65280-65535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__65280-65535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__65280-65535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__6656-6911.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__6656-6911.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__6656-6911.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__6912-7167.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__6912-7167.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__6912-7167.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__7168-7423.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__7168-7423.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__7168-7423.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__7424-7679.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__7424-7679.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__7424-7679.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__768-1023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__768-1023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__768-1023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__7680-7935.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__7680-7935.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__7680-7935.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__7936-8191.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__7936-8191.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__7936-8191.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__8192-8447.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__8192-8447.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__8192-8447.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__8448-8703.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__8448-8703.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__8448-8703.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__8704-8959.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__8704-8959.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__8704-8959.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__8960-9215.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__8960-9215.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__8960-9215.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__9216-9471.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__9216-9471.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__9216-9471.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__9472-9727.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__9472-9727.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__9472-9727.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__9728-9983.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__9728-9983.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__9728-9983.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Italic__9984-10239.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Italic__9984-10239.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Italic__9984-10239.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__0-255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__0-255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__0-255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__1024-1279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__1024-1279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__1024-1279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__10240-10495.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__10240-10495.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__10240-10495.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__10496-10751.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__10496-10751.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__10496-10751.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__10752-11007.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__10752-11007.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__10752-11007.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__11008-11263.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__11008-11263.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__11008-11263.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__11264-11519.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__11264-11519.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__11264-11519.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__11520-11775.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__11520-11775.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__11520-11775.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__11776-12031.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__11776-12031.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__11776-12031.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__12032-12287.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__12032-12287.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__12032-12287.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__12288-12543.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__12288-12543.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__12288-12543.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__12544-12799.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__12544-12799.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__12544-12799.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__1280-1535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__1280-1535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__1280-1535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__12800-13055.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__12800-13055.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__12800-13055.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__13056-13311.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__13056-13311.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__13056-13311.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__13312-13567.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__13312-13567.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__13312-13567.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__13568-13823.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__13568-13823.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__13568-13823.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__13824-14079.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__13824-14079.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__13824-14079.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__14080-14335.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__14080-14335.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__14080-14335.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__14336-14591.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__14336-14591.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__14336-14591.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__14592-14847.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__14592-14847.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__14592-14847.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__14848-15103.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__14848-15103.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__14848-15103.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__15104-15359.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__15104-15359.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__15104-15359.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__1536-1791.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__1536-1791.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__1536-1791.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__15360-15615.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__15360-15615.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__15360-15615.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__15616-15871.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__15616-15871.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__15616-15871.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__15872-16127.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__15872-16127.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__15872-16127.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__16128-16383.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__16128-16383.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__16128-16383.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__16384-16639.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__16384-16639.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__16384-16639.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__16640-16895.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__16640-16895.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__16640-16895.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__16896-17151.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__16896-17151.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__16896-17151.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__17152-17407.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__17152-17407.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__17152-17407.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__17408-17663.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__17408-17663.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__17408-17663.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__17664-17919.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__17664-17919.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__17664-17919.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__1792-2047.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__1792-2047.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__1792-2047.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__17920-18175.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__17920-18175.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__17920-18175.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__18176-18431.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__18176-18431.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__18176-18431.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__18432-18687.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__18432-18687.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__18432-18687.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__18688-18943.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__18688-18943.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__18688-18943.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__18944-19199.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__18944-19199.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__18944-19199.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__19200-19455.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__19200-19455.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__19200-19455.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__19456-19711.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__19456-19711.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__19456-19711.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__19712-19967.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__19712-19967.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__19712-19967.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__19968-20223.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__19968-20223.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__19968-20223.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__20224-20479.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__20224-20479.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__20224-20479.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__2048-2303.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__2048-2303.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__2048-2303.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__20480-20735.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__20480-20735.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__20480-20735.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__20736-20991.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__20736-20991.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__20736-20991.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__20992-21247.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__20992-21247.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__20992-21247.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__21248-21503.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__21248-21503.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__21248-21503.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__21504-21759.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__21504-21759.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__21504-21759.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__21760-22015.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__21760-22015.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__21760-22015.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__22016-22271.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__22016-22271.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__22016-22271.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__22272-22527.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__22272-22527.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__22272-22527.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__22528-22783.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__22528-22783.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__22528-22783.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__22784-23039.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__22784-23039.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__22784-23039.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__2304-2559.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__2304-2559.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__2304-2559.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__23040-23295.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__23040-23295.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__23040-23295.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__23296-23551.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__23296-23551.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__23296-23551.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__23552-23807.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__23552-23807.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__23552-23807.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__23808-24063.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__23808-24063.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__23808-24063.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__24064-24319.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__24064-24319.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__24064-24319.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__24320-24575.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__24320-24575.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__24320-24575.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__24576-24831.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__24576-24831.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__24576-24831.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__24832-25087.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__24832-25087.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__24832-25087.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__25088-25343.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__25088-25343.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__25088-25343.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__25344-25599.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__25344-25599.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__25344-25599.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__256-511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__256-511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__256-511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__2560-2815.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__2560-2815.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__2560-2815.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__25600-25855.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__25600-25855.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__25600-25855.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__25856-26111.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__25856-26111.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__25856-26111.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__26112-26367.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__26112-26367.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__26112-26367.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__26368-26623.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__26368-26623.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__26368-26623.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__26624-26879.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__26624-26879.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__26624-26879.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__26880-27135.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__26880-27135.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__26880-27135.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__27136-27391.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__27136-27391.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__27136-27391.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__27392-27647.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__27392-27647.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__27392-27647.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__27648-27903.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__27648-27903.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__27648-27903.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__27904-28159.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__27904-28159.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__27904-28159.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__2816-3071.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__2816-3071.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__2816-3071.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__28160-28415.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__28160-28415.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__28160-28415.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__28416-28671.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__28416-28671.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__28416-28671.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__28672-28927.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__28672-28927.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__28672-28927.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__28928-29183.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__28928-29183.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__28928-29183.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__29184-29439.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__29184-29439.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__29184-29439.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__29440-29695.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__29440-29695.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__29440-29695.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__29696-29951.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__29696-29951.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__29696-29951.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__29952-30207.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__29952-30207.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__29952-30207.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__30208-30463.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__30208-30463.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__30208-30463.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__30464-30719.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__30464-30719.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__30464-30719.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__3072-3327.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__3072-3327.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__3072-3327.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__30720-30975.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__30720-30975.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__30720-30975.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__30976-31231.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__30976-31231.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__30976-31231.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__31232-31487.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__31232-31487.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__31232-31487.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__31488-31743.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__31488-31743.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__31488-31743.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__31744-31999.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__31744-31999.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__31744-31999.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__32000-32255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__32000-32255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__32000-32255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__32256-32511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__32256-32511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__32256-32511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__32512-32767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__32512-32767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__32512-32767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__32768-33023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__32768-33023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__32768-33023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__33024-33279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__33024-33279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__33024-33279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__3328-3583.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__3328-3583.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__3328-3583.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__33280-33535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__33280-33535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__33280-33535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__33536-33791.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__33536-33791.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__33536-33791.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__33792-34047.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__33792-34047.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__33792-34047.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__34048-34303.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__34048-34303.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__34048-34303.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__34304-34559.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__34304-34559.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__34304-34559.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__34560-34815.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__34560-34815.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__34560-34815.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__34816-35071.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__34816-35071.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__34816-35071.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__35072-35327.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__35072-35327.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__35072-35327.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__35328-35583.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__35328-35583.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__35328-35583.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__35584-35839.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__35584-35839.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__35584-35839.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__3584-3839.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__3584-3839.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__3584-3839.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__35840-36095.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__35840-36095.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__35840-36095.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__36096-36351.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__36096-36351.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__36096-36351.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__36352-36607.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__36352-36607.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__36352-36607.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__36608-36863.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__36608-36863.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__36608-36863.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__36864-37119.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__36864-37119.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__36864-37119.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__37120-37375.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__37120-37375.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__37120-37375.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__37376-37631.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__37376-37631.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__37376-37631.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__37632-37887.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__37632-37887.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__37632-37887.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__37888-38143.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__37888-38143.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__37888-38143.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__38144-38399.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__38144-38399.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__38144-38399.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__3840-4095.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__3840-4095.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__3840-4095.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__38400-38655.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__38400-38655.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__38400-38655.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__38656-38911.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__38656-38911.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__38656-38911.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__38912-39167.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__38912-39167.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__38912-39167.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__39168-39423.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__39168-39423.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__39168-39423.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__39424-39679.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__39424-39679.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__39424-39679.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__39680-39935.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__39680-39935.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__39680-39935.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__39936-40191.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__39936-40191.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__39936-40191.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__40192-40447.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__40192-40447.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__40192-40447.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__40448-40703.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__40448-40703.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__40448-40703.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__40704-40959.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__40704-40959.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__40704-40959.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__4096-4351.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__4096-4351.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__4096-4351.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__40960-41215.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__40960-41215.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__40960-41215.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__41216-41471.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__41216-41471.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__41216-41471.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__41472-41727.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__41472-41727.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__41472-41727.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__41728-41983.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__41728-41983.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__41728-41983.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__41984-42239.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__41984-42239.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__41984-42239.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__42240-42495.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__42240-42495.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__42240-42495.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__42496-42751.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__42496-42751.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__42496-42751.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__42752-43007.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__42752-43007.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__42752-43007.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__43008-43263.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__43008-43263.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__43008-43263.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__43264-43519.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__43264-43519.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__43264-43519.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__4352-4607.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__4352-4607.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__4352-4607.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__43520-43775.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__43520-43775.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__43520-43775.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__43776-44031.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__43776-44031.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__43776-44031.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__44032-44287.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__44032-44287.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__44032-44287.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__44288-44543.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__44288-44543.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__44288-44543.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__44544-44799.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__44544-44799.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__44544-44799.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__44800-45055.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__44800-45055.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__44800-45055.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__45056-45311.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__45056-45311.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__45056-45311.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__45312-45567.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__45312-45567.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__45312-45567.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__45568-45823.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__45568-45823.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__45568-45823.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__45824-46079.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__45824-46079.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__45824-46079.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__4608-4863.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__4608-4863.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__4608-4863.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__46080-46335.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__46080-46335.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__46080-46335.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__46336-46591.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__46336-46591.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__46336-46591.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__46592-46847.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__46592-46847.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__46592-46847.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__46848-47103.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__46848-47103.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__46848-47103.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__47104-47359.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__47104-47359.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__47104-47359.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__47360-47615.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__47360-47615.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__47360-47615.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__47616-47871.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__47616-47871.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__47616-47871.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__47872-48127.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__47872-48127.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__47872-48127.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__48128-48383.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__48128-48383.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__48128-48383.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__48384-48639.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__48384-48639.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__48384-48639.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__4864-5119.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__4864-5119.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__4864-5119.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__48640-48895.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__48640-48895.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__48640-48895.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__48896-49151.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__48896-49151.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__48896-49151.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__49152-49407.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__49152-49407.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__49152-49407.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__49408-49663.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__49408-49663.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__49408-49663.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__49664-49919.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__49664-49919.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__49664-49919.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__49920-50175.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__49920-50175.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__49920-50175.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__50176-50431.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__50176-50431.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__50176-50431.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__50432-50687.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__50432-50687.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__50432-50687.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__50688-50943.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__50688-50943.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__50688-50943.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__50944-51199.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__50944-51199.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__50944-51199.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__512-767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__512-767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__512-767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__5120-5375.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__5120-5375.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__5120-5375.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__51200-51455.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__51200-51455.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__51200-51455.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__51456-51711.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__51456-51711.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__51456-51711.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__51712-51967.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__51712-51967.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__51712-51967.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__51968-52223.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__51968-52223.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__51968-52223.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__52224-52479.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__52224-52479.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__52224-52479.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__52480-52735.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__52480-52735.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__52480-52735.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__52736-52991.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__52736-52991.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__52736-52991.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__52992-53247.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__52992-53247.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__52992-53247.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__53248-53503.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__53248-53503.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__53248-53503.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__53504-53759.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__53504-53759.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__53504-53759.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__5376-5631.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__5376-5631.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__5376-5631.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__53760-54015.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__53760-54015.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__53760-54015.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__54016-54271.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__54016-54271.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__54016-54271.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__54272-54527.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__54272-54527.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__54272-54527.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__54528-54783.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__54528-54783.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__54528-54783.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__54784-55039.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__54784-55039.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__54784-55039.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__55040-55295.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__55040-55295.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__55040-55295.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__55296-55551.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__55296-55551.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__55296-55551.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__55552-55807.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__55552-55807.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__55552-55807.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__55808-56063.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__55808-56063.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__55808-56063.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__56064-56319.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__56064-56319.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__56064-56319.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__5632-5887.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__5632-5887.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__5632-5887.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__56320-56575.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__56320-56575.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__56320-56575.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__56576-56831.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__56576-56831.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__56576-56831.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__56832-57087.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__56832-57087.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__56832-57087.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__57088-57343.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__57088-57343.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__57088-57343.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__57344-57599.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__57344-57599.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__57344-57599.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__57600-57855.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__57600-57855.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__57600-57855.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__57856-58111.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__57856-58111.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__57856-58111.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__58112-58367.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__58112-58367.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__58112-58367.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__58368-58623.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__58368-58623.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__58368-58623.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__58624-58879.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__58624-58879.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__58624-58879.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__5888-6143.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__5888-6143.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__5888-6143.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__58880-59135.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__58880-59135.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__58880-59135.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__59136-59391.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__59136-59391.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__59136-59391.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__59392-59647.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__59392-59647.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__59392-59647.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__59648-59903.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__59648-59903.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__59648-59903.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__59904-60159.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__59904-60159.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__59904-60159.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__60160-60415.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__60160-60415.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__60160-60415.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__60416-60671.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__60416-60671.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__60416-60671.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__60672-60927.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__60672-60927.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__60672-60927.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__60928-61183.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__60928-61183.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__60928-61183.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__61184-61439.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__61184-61439.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__61184-61439.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__6144-6399.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__6144-6399.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__6144-6399.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__61440-61695.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__61440-61695.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__61440-61695.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__61696-61951.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__61696-61951.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__61696-61951.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__61952-62207.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__61952-62207.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__61952-62207.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__62208-62463.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__62208-62463.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__62208-62463.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__62464-62719.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__62464-62719.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__62464-62719.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__62720-62975.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__62720-62975.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__62720-62975.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__62976-63231.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__62976-63231.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__62976-63231.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__63232-63487.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__63232-63487.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__63232-63487.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__63488-63743.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__63488-63743.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__63488-63743.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__63744-63999.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__63744-63999.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__63744-63999.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__6400-6655.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__6400-6655.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__6400-6655.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__64000-64255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__64000-64255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__64000-64255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__64256-64511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__64256-64511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__64256-64511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__64512-64767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__64512-64767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__64512-64767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__64768-65023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__64768-65023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__64768-65023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__65024-65279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__65024-65279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__65024-65279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__65280-65535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__65280-65535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__65280-65535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__6656-6911.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__6656-6911.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__6656-6911.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__6912-7167.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__6912-7167.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__6912-7167.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__7168-7423.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__7168-7423.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__7168-7423.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__7424-7679.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__7424-7679.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__7424-7679.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__768-1023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__768-1023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__768-1023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__7680-7935.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__7680-7935.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__7680-7935.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__7936-8191.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__7936-8191.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__7936-8191.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__8192-8447.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__8192-8447.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__8192-8447.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__8448-8703.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__8448-8703.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__8448-8703.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__8704-8959.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__8704-8959.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__8704-8959.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__8960-9215.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__8960-9215.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__8960-9215.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__9216-9471.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__9216-9471.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__9216-9471.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__9472-9727.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__9472-9727.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__9472-9727.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__9728-9983.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__9728-9983.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__9728-9983.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro Regular__9984-10239.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro Regular__9984-10239.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20Regular__9984-10239.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__0-255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__0-255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__0-255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__1024-1279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__1024-1279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__1024-1279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__10240-10495.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__10240-10495.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__10240-10495.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__10496-10751.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__10496-10751.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__10496-10751.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__10752-11007.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__10752-11007.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__10752-11007.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__11008-11263.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__11008-11263.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__11008-11263.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__11264-11519.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__11264-11519.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__11264-11519.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__11520-11775.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__11520-11775.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__11520-11775.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__11776-12031.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__11776-12031.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__11776-12031.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__12032-12287.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__12032-12287.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__12032-12287.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__12288-12543.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__12288-12543.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__12288-12543.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__12544-12799.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__12544-12799.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__12544-12799.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__1280-1535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__1280-1535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__1280-1535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__12800-13055.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__12800-13055.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__12800-13055.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__13056-13311.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__13056-13311.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__13056-13311.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__13312-13567.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__13312-13567.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__13312-13567.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__13568-13823.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__13568-13823.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__13568-13823.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__13824-14079.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__13824-14079.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__13824-14079.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__14080-14335.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__14080-14335.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__14080-14335.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__14336-14591.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__14336-14591.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__14336-14591.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__14592-14847.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__14592-14847.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__14592-14847.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__14848-15103.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__14848-15103.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__14848-15103.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__15104-15359.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__15104-15359.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__15104-15359.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__1536-1791.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__1536-1791.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__1536-1791.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__15360-15615.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__15360-15615.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__15360-15615.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__15616-15871.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__15616-15871.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__15616-15871.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__15872-16127.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__15872-16127.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__15872-16127.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__16128-16383.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__16128-16383.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__16128-16383.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__16384-16639.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__16384-16639.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__16384-16639.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__16640-16895.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__16640-16895.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__16640-16895.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__16896-17151.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__16896-17151.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__16896-17151.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__17152-17407.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__17152-17407.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__17152-17407.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__17408-17663.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__17408-17663.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__17408-17663.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__17664-17919.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__17664-17919.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__17664-17919.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__1792-2047.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__1792-2047.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__1792-2047.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__17920-18175.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__17920-18175.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__17920-18175.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__18176-18431.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__18176-18431.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__18176-18431.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__18432-18687.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__18432-18687.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__18432-18687.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__18688-18943.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__18688-18943.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__18688-18943.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__18944-19199.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__18944-19199.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__18944-19199.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__19200-19455.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__19200-19455.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__19200-19455.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__19456-19711.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__19456-19711.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__19456-19711.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__19712-19967.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__19712-19967.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__19712-19967.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__19968-20223.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__19968-20223.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__19968-20223.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__20224-20479.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__20224-20479.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__20224-20479.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__2048-2303.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__2048-2303.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__2048-2303.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__20480-20735.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__20480-20735.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__20480-20735.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__20736-20991.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__20736-20991.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__20736-20991.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__20992-21247.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__20992-21247.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__20992-21247.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__21248-21503.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__21248-21503.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__21248-21503.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__21504-21759.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__21504-21759.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__21504-21759.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__21760-22015.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__21760-22015.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__21760-22015.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__22016-22271.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__22016-22271.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__22016-22271.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__22272-22527.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__22272-22527.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__22272-22527.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__22528-22783.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__22528-22783.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__22528-22783.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__22784-23039.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__22784-23039.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__22784-23039.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__2304-2559.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__2304-2559.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__2304-2559.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__23040-23295.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__23040-23295.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__23040-23295.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__23296-23551.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__23296-23551.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__23296-23551.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__23552-23807.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__23552-23807.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__23552-23807.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__23808-24063.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__23808-24063.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__23808-24063.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__24064-24319.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__24064-24319.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__24064-24319.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__24320-24575.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__24320-24575.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__24320-24575.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__24576-24831.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__24576-24831.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__24576-24831.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__24832-25087.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__24832-25087.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__24832-25087.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__25088-25343.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__25088-25343.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__25088-25343.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__25344-25599.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__25344-25599.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__25344-25599.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__256-511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__256-511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__256-511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__2560-2815.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__2560-2815.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__2560-2815.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__25600-25855.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__25600-25855.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__25600-25855.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__25856-26111.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__25856-26111.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__25856-26111.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__26112-26367.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__26112-26367.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__26112-26367.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__26368-26623.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__26368-26623.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__26368-26623.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__26624-26879.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__26624-26879.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__26624-26879.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__26880-27135.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__26880-27135.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__26880-27135.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__27136-27391.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__27136-27391.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__27136-27391.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__27392-27647.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__27392-27647.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__27392-27647.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__27648-27903.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__27648-27903.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__27648-27903.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__27904-28159.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__27904-28159.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__27904-28159.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__2816-3071.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__2816-3071.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__2816-3071.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__28160-28415.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__28160-28415.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__28160-28415.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__28416-28671.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__28416-28671.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__28416-28671.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__28672-28927.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__28672-28927.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__28672-28927.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__28928-29183.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__28928-29183.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__28928-29183.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__29184-29439.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__29184-29439.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__29184-29439.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__29440-29695.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__29440-29695.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__29440-29695.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__29696-29951.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__29696-29951.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__29696-29951.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__29952-30207.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__29952-30207.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__29952-30207.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__30208-30463.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__30208-30463.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__30208-30463.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__30464-30719.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__30464-30719.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__30464-30719.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__3072-3327.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__3072-3327.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__3072-3327.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__30720-30975.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__30720-30975.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__30720-30975.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__30976-31231.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__30976-31231.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__30976-31231.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__31232-31487.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__31232-31487.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__31232-31487.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__31488-31743.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__31488-31743.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__31488-31743.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__31744-31999.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__31744-31999.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__31744-31999.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__32000-32255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__32000-32255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__32000-32255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__32256-32511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__32256-32511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__32256-32511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__32512-32767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__32512-32767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__32512-32767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__32768-33023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__32768-33023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__32768-33023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__33024-33279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__33024-33279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__33024-33279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__3328-3583.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__3328-3583.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__3328-3583.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__33280-33535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__33280-33535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__33280-33535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__33536-33791.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__33536-33791.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__33536-33791.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__33792-34047.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__33792-34047.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__33792-34047.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__34048-34303.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__34048-34303.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__34048-34303.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__34304-34559.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__34304-34559.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__34304-34559.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__34560-34815.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__34560-34815.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__34560-34815.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__34816-35071.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__34816-35071.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__34816-35071.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__35072-35327.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__35072-35327.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__35072-35327.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__35328-35583.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__35328-35583.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__35328-35583.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__35584-35839.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__35584-35839.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__35584-35839.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__3584-3839.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__3584-3839.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__3584-3839.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__35840-36095.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__35840-36095.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__35840-36095.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__36096-36351.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__36096-36351.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__36096-36351.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__36352-36607.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__36352-36607.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__36352-36607.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__36608-36863.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__36608-36863.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__36608-36863.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__36864-37119.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__36864-37119.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__36864-37119.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__37120-37375.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__37120-37375.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__37120-37375.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__37376-37631.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__37376-37631.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__37376-37631.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__37632-37887.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__37632-37887.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__37632-37887.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__37888-38143.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__37888-38143.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__37888-38143.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__38144-38399.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__38144-38399.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__38144-38399.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__3840-4095.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__3840-4095.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__3840-4095.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__38400-38655.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__38400-38655.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__38400-38655.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__38656-38911.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__38656-38911.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__38656-38911.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__38912-39167.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__38912-39167.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__38912-39167.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__39168-39423.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__39168-39423.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__39168-39423.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__39424-39679.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__39424-39679.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__39424-39679.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__39680-39935.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__39680-39935.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__39680-39935.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__39936-40191.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__39936-40191.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__39936-40191.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__40192-40447.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__40192-40447.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__40192-40447.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__40448-40703.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__40448-40703.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__40448-40703.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__40704-40959.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__40704-40959.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__40704-40959.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__4096-4351.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__4096-4351.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__4096-4351.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__40960-41215.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__40960-41215.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__40960-41215.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__41216-41471.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__41216-41471.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__41216-41471.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__41472-41727.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__41472-41727.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__41472-41727.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__41728-41983.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__41728-41983.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__41728-41983.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__41984-42239.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__41984-42239.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__41984-42239.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__42240-42495.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__42240-42495.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__42240-42495.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__42496-42751.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__42496-42751.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__42496-42751.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__42752-43007.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__42752-43007.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__42752-43007.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__43008-43263.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__43008-43263.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__43008-43263.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__43264-43519.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__43264-43519.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__43264-43519.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__4352-4607.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__4352-4607.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__4352-4607.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__43520-43775.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__43520-43775.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__43520-43775.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__43776-44031.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__43776-44031.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__43776-44031.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__44032-44287.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__44032-44287.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__44032-44287.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__44288-44543.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__44288-44543.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__44288-44543.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__44544-44799.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__44544-44799.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__44544-44799.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__44800-45055.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__44800-45055.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__44800-45055.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__45056-45311.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__45056-45311.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__45056-45311.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__45312-45567.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__45312-45567.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__45312-45567.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__45568-45823.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__45568-45823.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__45568-45823.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__45824-46079.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__45824-46079.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__45824-46079.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__4608-4863.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__4608-4863.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__4608-4863.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__46080-46335.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__46080-46335.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__46080-46335.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__46336-46591.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__46336-46591.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__46336-46591.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__46592-46847.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__46592-46847.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__46592-46847.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__46848-47103.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__46848-47103.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__46848-47103.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__47104-47359.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__47104-47359.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__47104-47359.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__47360-47615.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__47360-47615.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__47360-47615.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__47616-47871.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__47616-47871.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__47616-47871.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__47872-48127.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__47872-48127.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__47872-48127.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__48128-48383.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__48128-48383.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__48128-48383.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__48384-48639.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__48384-48639.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__48384-48639.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__4864-5119.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__4864-5119.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__4864-5119.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__48640-48895.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__48640-48895.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__48640-48895.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__48896-49151.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__48896-49151.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__48896-49151.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__49152-49407.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__49152-49407.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__49152-49407.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__49408-49663.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__49408-49663.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__49408-49663.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__49664-49919.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__49664-49919.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__49664-49919.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__49920-50175.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__49920-50175.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__49920-50175.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__50176-50431.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__50176-50431.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__50176-50431.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__50432-50687.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__50432-50687.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__50432-50687.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__50688-50943.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__50688-50943.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__50688-50943.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__50944-51199.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__50944-51199.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__50944-51199.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__512-767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__512-767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__512-767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__5120-5375.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__5120-5375.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__5120-5375.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__51200-51455.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__51200-51455.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__51200-51455.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__51456-51711.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__51456-51711.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__51456-51711.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__51712-51967.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__51712-51967.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__51712-51967.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__51968-52223.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__51968-52223.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__51968-52223.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__52224-52479.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__52224-52479.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__52224-52479.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__52480-52735.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__52480-52735.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__52480-52735.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__52736-52991.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__52736-52991.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__52736-52991.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__52992-53247.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__52992-53247.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__52992-53247.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__53248-53503.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__53248-53503.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__53248-53503.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__53504-53759.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__53504-53759.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__53504-53759.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__5376-5631.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__5376-5631.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__5376-5631.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__53760-54015.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__53760-54015.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__53760-54015.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__54016-54271.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__54016-54271.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__54016-54271.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__54272-54527.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__54272-54527.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__54272-54527.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__54528-54783.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__54528-54783.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__54528-54783.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__54784-55039.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__54784-55039.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__54784-55039.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__55040-55295.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__55040-55295.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__55040-55295.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__55296-55551.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__55296-55551.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__55296-55551.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__55552-55807.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__55552-55807.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__55552-55807.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__55808-56063.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__55808-56063.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__55808-56063.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__56064-56319.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__56064-56319.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__56064-56319.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__5632-5887.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__5632-5887.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__5632-5887.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__56320-56575.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__56320-56575.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__56320-56575.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__56576-56831.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__56576-56831.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__56576-56831.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__56832-57087.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__56832-57087.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__56832-57087.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__57088-57343.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__57088-57343.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__57088-57343.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__57344-57599.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__57344-57599.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__57344-57599.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__57600-57855.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__57600-57855.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__57600-57855.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__57856-58111.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__57856-58111.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__57856-58111.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__58112-58367.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__58112-58367.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__58112-58367.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__58368-58623.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__58368-58623.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__58368-58623.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__58624-58879.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__58624-58879.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__58624-58879.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__5888-6143.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__5888-6143.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__5888-6143.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__58880-59135.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__58880-59135.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__58880-59135.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__59136-59391.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__59136-59391.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__59136-59391.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__59392-59647.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__59392-59647.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__59392-59647.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__59648-59903.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__59648-59903.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__59648-59903.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__59904-60159.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__59904-60159.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__59904-60159.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__60160-60415.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__60160-60415.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__60160-60415.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__60416-60671.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__60416-60671.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__60416-60671.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__60672-60927.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__60672-60927.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__60672-60927.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__60928-61183.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__60928-61183.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__60928-61183.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__61184-61439.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__61184-61439.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__61184-61439.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__6144-6399.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__6144-6399.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__6144-6399.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__61440-61695.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__61440-61695.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__61440-61695.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__61696-61951.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__61696-61951.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__61696-61951.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__61952-62207.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__61952-62207.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__61952-62207.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__62208-62463.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__62208-62463.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__62208-62463.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__62464-62719.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__62464-62719.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__62464-62719.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__62720-62975.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__62720-62975.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__62720-62975.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__62976-63231.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__62976-63231.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__62976-63231.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__63232-63487.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__63232-63487.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__63232-63487.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__63488-63743.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__63488-63743.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__63488-63743.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__63744-63999.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__63744-63999.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__63744-63999.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__6400-6655.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__6400-6655.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__6400-6655.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__64000-64255.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__64000-64255.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__64000-64255.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__64256-64511.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__64256-64511.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__64256-64511.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__64512-64767.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__64512-64767.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__64512-64767.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__64768-65023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__64768-65023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__64768-65023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__65024-65279.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__65024-65279.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__65024-65279.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__65280-65535.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__65280-65535.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__65280-65535.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__6656-6911.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__6656-6911.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__6656-6911.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__6912-7167.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__6912-7167.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__6912-7167.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__7168-7423.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__7168-7423.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__7168-7423.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__7424-7679.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__7424-7679.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__7424-7679.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__768-1023.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__768-1023.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__768-1023.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__7680-7935.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__7680-7935.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__7680-7935.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__7936-8191.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__7936-8191.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__7936-8191.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__8192-8447.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__8192-8447.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__8192-8447.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__8448-8703.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__8448-8703.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__8448-8703.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__8704-8959.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__8704-8959.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__8704-8959.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__8960-9215.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__8960-9215.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__8960-9215.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__9216-9471.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__9216-9471.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__9216-9471.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__9472-9727.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__9472-9727.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__9472-9727.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__9728-9983.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__9728-9983.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__9728-9983.pbf"
+      }
+    },
+    {
+      "id": "Source Sans Pro SemiBold__9984-10239.pbf",
+      "link": {
+        "rel": "item",
+        "title": "Source Sans Pro SemiBold__9984-10239.pbf",
+        "href": "https://my.server.org/sample-data/resources/Source%20Sans%20Pro%20SemiBold__9984-10239.pbf"
+      }
+    },
+    {
+      "id": "UG.svg",
+      "link": {
+        "rel": "item",
+        "title": "UG.svg",
+        "href": "https://my.server.org/sample-data/resources/UG.svg"
+      }
+    },
+    {
+      "id": "output",
+      "link": {
+        "rel": "item",
+        "title": "output",
+        "href": "https://my.server.org/sample-data/resources/output"
+      }
+    },
+    {
+      "id": "sprites.json",
+      "link": {
+        "rel": "item",
+        "title": "sprites.json",
+        "href": "https://my.server.org/sample-data/resources/sprites.json"
+      }
+    },
+    {
+      "id": "sprites.png",
+      "link": {
+        "rel": "item",
+        "title": "sprites.png",
+        "href": "https://my.server.org/sample-data/resources/sprites.png"
+      }
+    },
+    {
+      "id": "sprites@2x.json",
+      "link": {
+        "rel": "item",
+        "title": "sprites@2x.json",
+        "href": "https://my.server.org/sample-data/resources/sprites@2x.json"
+      }
+    },
+    {
+      "id": "sprites@2x.png",
+      "link": {
+        "rel": "item",
+        "title": "sprites@2x.png",
+        "href": "https://my.server.org/sample-data/resources/sprites@2x.png"
+      }
+    },
+    {
+      "id": "sprites@3x.json",
+      "link": {
+        "rel": "item",
+        "title": "sprites@3x.json",
+        "href": "https://my.server.org/sample-data/resources/sprites@3x.json"
+      }
+    },
+    {
+      "id": "sprites@3x.png",
+      "link": {
+        "rel": "item",
+        "title": "sprites@3x.png",
+        "href": "https://my.server.org/sample-data/resources/sprites@3x.png"
+      }
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/styles.json
+++ b/fixtures/ogc-api/sample-data/styles.json
@@ -1,0 +1,191 @@
+{
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data/styles?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/styles?f=html"
+    }
+  ],
+  "styles": [
+    {
+      "title": "Deuteranopia",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.esri.lyr",
+          "title": "Style in format 'ArcGIS'",
+          "href": "https://my.server.org/sample-data/styles/Deuteranopia?f=lyr"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/styles/Deuteranopia/metadata"
+        }
+      ],
+      "id": "Deuteranopia"
+    },
+    {
+      "title": "OS Open Zoomstack - Light",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.esri.lyr",
+          "title": "Style in format 'ArcGIS'",
+          "href": "https://my.server.org/sample-data/styles/Light?f=lyr"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "text/html",
+          "title": "Web map using the style",
+          "href": "https://my.server.org/sample-data/styles/Light?f=html"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.mapbox.style+json",
+          "title": "Style in format 'Mapbox'",
+          "href": "https://my.server.org/sample-data/styles/Light?f=mbs"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/styles/Light/metadata"
+        }
+      ],
+      "id": "Light"
+    },
+    {
+      "title": "OS Open Zoomstack - Night",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.esri.lyr",
+          "title": "Style in format 'ArcGIS'",
+          "href": "https://my.server.org/sample-data/styles/Night?f=lyr"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "text/html",
+          "title": "Web map using the style",
+          "href": "https://my.server.org/sample-data/styles/Night?f=html"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.mapbox.style+json",
+          "title": "Style in format 'Mapbox'",
+          "href": "https://my.server.org/sample-data/styles/Night?f=mbs"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/styles/Night/metadata"
+        }
+      ],
+      "id": "Night"
+    },
+    {
+      "title": "OS Open Zoomstack - Outdoor",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.esri.lyr",
+          "title": "Style in format 'ArcGIS'",
+          "href": "https://my.server.org/sample-data/styles/Outdoor?f=lyr"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "text/html",
+          "title": "Web map using the style",
+          "href": "https://my.server.org/sample-data/styles/Outdoor?f=html"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.mapbox.style+json",
+          "title": "Style in format 'Mapbox'",
+          "href": "https://my.server.org/sample-data/styles/Outdoor?f=mbs"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/styles/Outdoor/metadata"
+        }
+      ],
+      "id": "Outdoor"
+    },
+    {
+      "title": "OS Open Zoomstack - Outdoor with Hillshade",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "text/html",
+          "title": "Web map using the style",
+          "href": "https://my.server.org/sample-data/styles/OutdoorHillshade?f=html"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.mapbox.style+json",
+          "title": "Style in format 'Mapbox'",
+          "href": "https://my.server.org/sample-data/styles/OutdoorHillshade?f=mbs"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/styles/OutdoorHillshade/metadata"
+        }
+      ],
+      "id": "OutdoorHillshade"
+    },
+    {
+      "title": "OS Open Zoomstack - Road",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.esri.lyr",
+          "title": "Style in format 'ArcGIS'",
+          "href": "https://my.server.org/sample-data/styles/Road?f=lyr"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "text/html",
+          "title": "Web map using the style",
+          "href": "https://my.server.org/sample-data/styles/Road?f=html"
+        },
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.mapbox.style+json",
+          "title": "Style in format 'Mapbox'",
+          "href": "https://my.server.org/sample-data/styles/Road?f=mbs"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/styles/Road/metadata"
+        }
+      ],
+      "id": "Road"
+    },
+    {
+      "title": "Tritanopia",
+      "links": [
+        {
+          "rel": "stylesheet",
+          "type": "application/vnd.esri.lyr",
+          "title": "Style in format 'ArcGIS'",
+          "href": "https://my.server.org/sample-data/styles/Tritanopia?f=lyr"
+        },
+        {
+          "rel": "describedby",
+          "title": "Style metadata",
+          "href": "https://my.server.org/sample-data/styles/Tritanopia/metadata"
+        }
+      ],
+      "id": "Tritanopia"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/tileMatrixSets.json
+++ b/fixtures/ogc-api/sample-data/tileMatrixSets.json
@@ -1,0 +1,30 @@
+{
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://demo.ldproxy.net/zoomstack/tileMatrixSets?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://demo.ldproxy.net/zoomstack/tileMatrixSets?f=html"
+    }
+  ],
+  "tileMatrixSets": [
+    {
+      "title": "Google Maps Compatible for the World",
+      "links": [
+        {
+          "rel": "self",
+          "title": "Tile matrix set 'WebMercatorQuad'",
+          "href": "https://demo.ldproxy.net/zoomstack/tileMatrixSets/WebMercatorQuad"
+        }
+      ],
+      "id": "WebMercatorQuad",
+      "uri": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/tileMatrixSets/WebMercatorQuad.json
+++ b/fixtures/ogc-api/sample-data/tileMatrixSets/WebMercatorQuad.json
@@ -1,0 +1,299 @@
+{
+  "title": "Google Maps Compatible for the World",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://demo.ldproxy.net/zoomstack/tileMatrixSets/WebMercatorQuad?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://demo.ldproxy.net/zoomstack/tileMatrixSets/WebMercatorQuad?f=html"
+    }
+  ],
+  "id": "WebMercatorQuad",
+  "crs": "http://www.opengis.net/def/crs/EPSG/0/3857",
+  "wellKnownScaleSet": "http://www.opengis.net/def/wkss/OGC/1.0/GoogleMapsCompatible",
+  "uri": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+  "tileMatrices": [
+    {
+      "id": "0",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 1,
+      "matrixHeight": 1,
+      "scaleDenominator": 559082264.028717,
+      "cellSize": 156543.033928041,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "1",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 2,
+      "matrixHeight": 2,
+      "scaleDenominator": 279541132.014358,
+      "cellSize": 78271.5169640204,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "2",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 4,
+      "matrixHeight": 4,
+      "scaleDenominator": 139770566.007179,
+      "cellSize": 39135.7584820102,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "3",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 8,
+      "matrixHeight": 8,
+      "scaleDenominator": 69885283.0035897,
+      "cellSize": 19567.8792410051,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "4",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 16,
+      "matrixHeight": 16,
+      "scaleDenominator": 34942641.5017948,
+      "cellSize": 9783.93962050256,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "5",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 32,
+      "matrixHeight": 32,
+      "scaleDenominator": 17471320.7508974,
+      "cellSize": 4891.96981025128,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "6",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 64,
+      "matrixHeight": 64,
+      "scaleDenominator": 8735660.37544871,
+      "cellSize": 2445.98490512564,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "7",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 128,
+      "matrixHeight": 128,
+      "scaleDenominator": 4367830.18772435,
+      "cellSize": 1222.99245256282,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "8",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 256,
+      "matrixHeight": 256,
+      "scaleDenominator": 2183915.09386217,
+      "cellSize": 611.49622628141,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "9",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 512,
+      "matrixHeight": 512,
+      "scaleDenominator": 1091957.54693108,
+      "cellSize": 305.748113140704,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "10",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 1024,
+      "matrixHeight": 1024,
+      "scaleDenominator": 545978.773465544,
+      "cellSize": 152.874056570352,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "11",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 2048,
+      "matrixHeight": 2048,
+      "scaleDenominator": 272989.386732772,
+      "cellSize": 76.4370282851762,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "12",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 4096,
+      "matrixHeight": 4096,
+      "scaleDenominator": 136494.693366386,
+      "cellSize": 38.2185141425881,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "13",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 8192,
+      "matrixHeight": 8192,
+      "scaleDenominator": 68247.346683193,
+      "cellSize": 19.109257071294,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "14",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 16384,
+      "matrixHeight": 16384,
+      "scaleDenominator": 34123.6733415964,
+      "cellSize": 9.55462853564703,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "15",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 32768,
+      "matrixHeight": 32768,
+      "scaleDenominator": 17061.8366707982,
+      "cellSize": 4.77731426782351,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "16",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 65536,
+      "matrixHeight": 65536,
+      "scaleDenominator": 8530.91833539913,
+      "cellSize": 2.38865713391175,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "17",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 131072,
+      "matrixHeight": 131072,
+      "scaleDenominator": 4265.45916769956,
+      "cellSize": 1.19432856695587,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "18",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 262144,
+      "matrixHeight": 262144,
+      "scaleDenominator": 2132.72958384978,
+      "cellSize": 0.597164283477939,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "19",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 524288,
+      "matrixHeight": 524288,
+      "scaleDenominator": 1066.36479192489,
+      "cellSize": 0.29858214173897,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "20",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 1048576,
+      "matrixHeight": 1048576,
+      "scaleDenominator": 533.182395962445,
+      "cellSize": 0.149291070869485,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "21",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 2097152,
+      "matrixHeight": 2097152,
+      "scaleDenominator": 266.591197981222,
+      "cellSize": 0.0746455354347424,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "22",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 4194304,
+      "matrixHeight": 4194304,
+      "scaleDenominator": 133.295598990611,
+      "cellSize": 0.0373227677173712,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "23",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 8388608,
+      "matrixHeight": 8388608,
+      "scaleDenominator": 66.6477994953056,
+      "cellSize": 0.0186613838586856,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    },
+    {
+      "id": "24",
+      "tileWidth": 256,
+      "tileHeight": 256,
+      "matrixWidth": 16777216,
+      "matrixHeight": 16777216,
+      "scaleDenominator": 33.3238997476528,
+      "cellSize": 0.0093306919293428,
+      "pointOfOrigin": [-20037508.3427892, 20037508.3427892],
+      "cornerOfOrigin": "topLeft"
+    }
+  ],
+  "orderedAxes": ["X", "Y"]
+}

--- a/fixtures/ogc-api/sample-data/tiles.json
+++ b/fixtures/ogc-api/sample-data/tiles.json
@@ -1,0 +1,382 @@
+{
+  "title": "OS Open Zoomstack",
+  "description": "OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data/tiles?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/tiles?f=html"
+    }
+  ],
+  "tilesets": [
+    {
+      "links": [
+        {
+          "rel": "self",
+          "title": "Access the data as tiles in the tile matrix set 'WebMercatorQuad'",
+          "href": "https://my.server.org/sample-data/tiles/WebMercatorQuad"
+        },
+        {
+          "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme",
+          "title": "Definition of the tiling scheme",
+          "href": "https://my.server.org/sample-data/tileMatrixSets/WebMercatorQuad"
+        },
+        {
+          "rel": "item",
+          "type": "application/vnd.mapbox-vector-tile",
+          "title": "Mapbox vector tiles; the link is a URI template where {tileMatrix}/{tileRow}/{tileCol} is the tile in the tiling scheme 'WebMercatorQuad'",
+          "href": "https://my.server.org/sample-data/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt",
+          "templated": true
+        }
+      ],
+      "dataType": "vector",
+      "tileMatrixSetId": "WebMercatorQuad",
+      "tileMatrixSetURI": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+      "tileMatrixSetLimits": [
+        {
+          "numberOfTiles": 1,
+          "tileMatrix": "0",
+          "minTileRow": 0,
+          "maxTileRow": 0,
+          "minTileCol": 0,
+          "maxTileCol": 0
+        },
+        {
+          "numberOfTiles": 2,
+          "tileMatrix": "1",
+          "minTileRow": 0,
+          "maxTileRow": 0,
+          "minTileCol": 0,
+          "maxTileCol": 1
+        },
+        {
+          "numberOfTiles": 2,
+          "tileMatrix": "2",
+          "minTileRow": 1,
+          "maxTileRow": 1,
+          "minTileCol": 1,
+          "maxTileCol": 2
+        },
+        {
+          "numberOfTiles": 2,
+          "tileMatrix": "3",
+          "minTileRow": 2,
+          "maxTileRow": 2,
+          "minTileCol": 3,
+          "maxTileCol": 4
+        },
+        {
+          "numberOfTiles": 4,
+          "tileMatrix": "4",
+          "minTileRow": 4,
+          "maxTileRow": 5,
+          "minTileCol": 7,
+          "maxTileCol": 8
+        },
+        {
+          "numberOfTiles": 4,
+          "tileMatrix": "5",
+          "minTileRow": 9,
+          "maxTileRow": 10,
+          "minTileCol": 15,
+          "maxTileCol": 16
+        },
+        {
+          "numberOfTiles": 12,
+          "tileMatrix": "6",
+          "minTileRow": 18,
+          "maxTileRow": 21,
+          "minTileCol": 30,
+          "maxTileCol": 32
+        },
+        {
+          "numberOfTiles": 40,
+          "tileMatrix": "7",
+          "minTileRow": 36,
+          "maxTileRow": 43,
+          "minTileCol": 60,
+          "maxTileCol": 64
+        },
+        {
+          "numberOfTiles": 135,
+          "tileMatrix": "8",
+          "minTileRow": 73,
+          "maxTileRow": 87,
+          "minTileCol": 121,
+          "maxTileCol": 129
+        },
+        {
+          "numberOfTiles": 522,
+          "tileMatrix": "9",
+          "minTileRow": 146,
+          "maxTileRow": 174,
+          "minTileCol": 242,
+          "maxTileCol": 259
+        },
+        {
+          "numberOfTiles": 1995,
+          "tileMatrix": "10",
+          "minTileRow": 292,
+          "maxTileRow": 348,
+          "minTileCol": 485,
+          "maxTileCol": 519
+        },
+        {
+          "numberOfTiles": 7728,
+          "tileMatrix": "11",
+          "minTileRow": 585,
+          "maxTileRow": 696,
+          "minTileCol": 971,
+          "maxTileCol": 1039
+        },
+        {
+          "numberOfTiles": 30414,
+          "tileMatrix": "12",
+          "minTileRow": 1171,
+          "maxTileRow": 1392,
+          "minTileCol": 1942,
+          "maxTileCol": 2078
+        },
+        {
+          "numberOfTiles": 120939,
+          "tileMatrix": "13",
+          "minTileRow": 2342,
+          "maxTileRow": 2784,
+          "minTileCol": 3885,
+          "maxTileCol": 4157
+        },
+        {
+          "numberOfTiles": 481440,
+          "tileMatrix": "14",
+          "minTileRow": 4685,
+          "maxTileRow": 5569,
+          "minTileCol": 7771,
+          "maxTileCol": 8314
+        }
+      ],
+      "boundingBox": {
+        "lowerLeft": [-9.2305667, 49.8168025],
+        "upperRight": [2.6954786, 60.7838866],
+        "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      },
+      "centerPoint": {
+        "coordinates": [-3.2835, 58.6359],
+        "tileMatrix": "10"
+      },
+      "layers": [
+        {
+          "title": "sea",
+          "id": "sea",
+          "dataType": "vector"
+        },
+        {
+          "title": "names",
+          "id": "names",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "name2language": {
+                "type": "string"
+              },
+              "name1language": {
+                "type": "string"
+              },
+              "name1": {
+                "type": "string"
+              },
+              "name2": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "rail",
+          "id": "rail",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "waterlines",
+          "id": "waterlines",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "etl",
+          "id": "etl",
+          "dataType": "vector"
+        },
+        {
+          "title": "foreshore",
+          "id": "foreshore",
+          "dataType": "vector"
+        },
+        {
+          "title": "sites",
+          "id": "sites",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "railwaystations",
+          "id": "railwaystations",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "roads",
+          "id": "roads",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "level": {
+                "type": "number"
+              },
+              "number": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "greenspaces",
+          "id": "greenspaces",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "contours",
+          "id": "contours",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "height": {
+                "type": "number"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "buildings",
+          "id": "buildings",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "uuid": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "boundaries",
+          "id": "boundaries",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "airports",
+          "id": "airports",
+          "dataType": "vector",
+          "propertiesSchema": {
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        {
+          "title": "woodland",
+          "id": "woodland",
+          "dataType": "vector"
+        },
+        {
+          "title": "national_parks",
+          "id": "national_parks",
+          "dataType": "vector"
+        },
+        {
+          "title": "urban_areas",
+          "id": "urban_areas",
+          "dataType": "vector"
+        },
+        {
+          "title": "surfacewater",
+          "id": "surfacewater",
+          "dataType": "vector"
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/tiles/WebMercatorQuad.json
+++ b/fixtures/ogc-api/sample-data/tiles/WebMercatorQuad.json
@@ -1,0 +1,369 @@
+{
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://demo.ldproxy.net/zoomstack/tiles/WebMercatorQuad?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "application/vnd.mapbox.tile+json",
+      "title": "This document as TileJSON",
+      "href": "https://demo.ldproxy.net/zoomstack/tiles/WebMercatorQuad?f=tilejson"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme",
+      "title": "Definition of the tiling scheme",
+      "href": "https://demo.ldproxy.net/zoomstack/tileMatrixSets/WebMercatorQuad"
+    },
+    {
+      "rel": "item",
+      "type": "application/vnd.mapbox-vector-tile",
+      "title": "Mapbox vector tiles; the link is a URI template where {tileMatrix}/{tileRow}/{tileCol} is the tile in the tiling scheme '{{tileMatrixSetId}}'",
+      "href": "https://demo.ldproxy.net/zoomstack/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt",
+      "templated": true
+    }
+  ],
+  "dataType": "vector",
+  "tileMatrixSetId": "WebMercatorQuad",
+  "tileMatrixSetURI": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+  "tileMatrixSetLimits": [
+    {
+      "numberOfTiles": 1,
+      "tileMatrix": "0",
+      "minTileRow": 0,
+      "maxTileRow": 0,
+      "minTileCol": 0,
+      "maxTileCol": 0
+    },
+    {
+      "numberOfTiles": 2,
+      "tileMatrix": "1",
+      "minTileRow": 0,
+      "maxTileRow": 0,
+      "minTileCol": 0,
+      "maxTileCol": 1
+    },
+    {
+      "numberOfTiles": 2,
+      "tileMatrix": "2",
+      "minTileRow": 1,
+      "maxTileRow": 1,
+      "minTileCol": 1,
+      "maxTileCol": 2
+    },
+    {
+      "numberOfTiles": 2,
+      "tileMatrix": "3",
+      "minTileRow": 2,
+      "maxTileRow": 2,
+      "minTileCol": 3,
+      "maxTileCol": 4
+    },
+    {
+      "numberOfTiles": 4,
+      "tileMatrix": "4",
+      "minTileRow": 4,
+      "maxTileRow": 5,
+      "minTileCol": 7,
+      "maxTileCol": 8
+    },
+    {
+      "numberOfTiles": 4,
+      "tileMatrix": "5",
+      "minTileRow": 9,
+      "maxTileRow": 10,
+      "minTileCol": 15,
+      "maxTileCol": 16
+    },
+    {
+      "numberOfTiles": 12,
+      "tileMatrix": "6",
+      "minTileRow": 18,
+      "maxTileRow": 21,
+      "minTileCol": 30,
+      "maxTileCol": 32
+    },
+    {
+      "numberOfTiles": 40,
+      "tileMatrix": "7",
+      "minTileRow": 36,
+      "maxTileRow": 43,
+      "minTileCol": 60,
+      "maxTileCol": 64
+    },
+    {
+      "numberOfTiles": 135,
+      "tileMatrix": "8",
+      "minTileRow": 73,
+      "maxTileRow": 87,
+      "minTileCol": 121,
+      "maxTileCol": 129
+    },
+    {
+      "numberOfTiles": 522,
+      "tileMatrix": "9",
+      "minTileRow": 146,
+      "maxTileRow": 174,
+      "minTileCol": 242,
+      "maxTileCol": 259
+    },
+    {
+      "numberOfTiles": 1995,
+      "tileMatrix": "10",
+      "minTileRow": 292,
+      "maxTileRow": 348,
+      "minTileCol": 485,
+      "maxTileCol": 519
+    },
+    {
+      "numberOfTiles": 7728,
+      "tileMatrix": "11",
+      "minTileRow": 585,
+      "maxTileRow": 696,
+      "minTileCol": 971,
+      "maxTileCol": 1039
+    },
+    {
+      "numberOfTiles": 30414,
+      "tileMatrix": "12",
+      "minTileRow": 1171,
+      "maxTileRow": 1392,
+      "minTileCol": 1942,
+      "maxTileCol": 2078
+    },
+    {
+      "numberOfTiles": 120939,
+      "tileMatrix": "13",
+      "minTileRow": 2342,
+      "maxTileRow": 2784,
+      "minTileCol": 3885,
+      "maxTileCol": 4157
+    },
+    {
+      "numberOfTiles": 481440,
+      "tileMatrix": "14",
+      "minTileRow": 4685,
+      "maxTileRow": 5569,
+      "minTileCol": 7771,
+      "maxTileCol": 8314
+    }
+  ],
+  "boundingBox": {
+    "lowerLeft": [-9.2305667, 49.8168025],
+    "upperRight": [2.6954786, 60.7838866],
+    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+  },
+  "centerPoint": {
+    "coordinates": [-3.2835, 58.6359],
+    "tileMatrix": "10"
+  },
+  "layers": [
+    {
+      "title": "sea",
+      "id": "sea",
+      "dataType": "vector"
+    },
+    {
+      "title": "names",
+      "id": "names",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "name2language": {
+            "type": "string"
+          },
+          "name1language": {
+            "type": "string"
+          },
+          "name1": {
+            "type": "string"
+          },
+          "name2": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "rail",
+      "id": "rail",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "waterlines",
+      "id": "waterlines",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "etl",
+      "id": "etl",
+      "dataType": "vector"
+    },
+    {
+      "title": "foreshore",
+      "id": "foreshore",
+      "dataType": "vector"
+    },
+    {
+      "title": "sites",
+      "id": "sites",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "railwaystations",
+      "id": "railwaystations",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "roads",
+      "id": "roads",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "level": {
+            "type": "number"
+          },
+          "number": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "greenspaces",
+      "id": "greenspaces",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "contours",
+      "id": "contours",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "height": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "buildings",
+      "id": "buildings",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "uuid": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "boundaries",
+      "id": "boundaries",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "airports",
+      "id": "airports",
+      "dataType": "vector",
+      "propertiesSchema": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    {
+      "title": "woodland",
+      "id": "woodland",
+      "dataType": "vector"
+    },
+    {
+      "title": "national_parks",
+      "id": "national_parks",
+      "dataType": "vector"
+    },
+    {
+      "title": "urban_areas",
+      "id": "urban_areas",
+      "dataType": "vector"
+    },
+    {
+      "title": "surfacewater",
+      "id": "surfacewater",
+      "dataType": "vector"
+    }
+  ]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,9 +5,10 @@ module.exports = {
       '<rootDir>/jest.ts-transformer.js',
       {
         isolatedModules: true,
-        stringifyContentPathRegex: '\\.(xml)$',
+        stringifyContentPathRegex: '.(xml)$',
       },
     ],
   },
   setupFilesAfterEnv: ['./test-setup.ts'],
+  coveragePathIgnorePatterns: ['.(xml)$'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.0.5",
         "@rollup/plugin-typescript": "^10.0.1",
+        "@types/geojson": "^7946.0.10",
         "@types/jest": "^29.2.4",
         "@types/node": "^18.11.18",
         "browser-cache-mock": "^0.1.7",
@@ -1384,6 +1385,12 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -6442,6 +6449,12 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
       "dev": true
     },
     "@types/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.5",
     "@rollup/plugin-typescript": "^10.0.1",
+    "@types/geojson": "^7946.0.10",
     "@types/jest": "^29.2.4",
     "@types/node": "^18.11.18",
     "browser-cache-mock": "^0.1.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export {
   LayerStyle,
   LayerAttribution,
 } from './wms/endpoint';
+export { default as OgcApiEndpoint } from './ogc-api/endpoint';
 export { useCache } from './shared/cache';
 export { sharedFetch } from './shared/http-utils';
 

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -44,7 +44,7 @@ describe('OgcApiEndpoint', () => {
         });
       });
     });
-    describe('#confitemsormanceClasses', () => {
+    describe('#conformanceClasses', () => {
       it('returns conformance classes', async () => {
         await expect(endpoint.conformanceClasses).resolves.toEqual([
           'http://www.opengis.net/spec/cql2/0.0/conf/advanced-comparison-operators',

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -44,7 +44,7 @@ describe('OgcApiEndpoint', () => {
         });
       });
     });
-    describe('#conformanceClasses', () => {
+    describe('#confitemsormanceClasses', () => {
       it('returns conformance classes', async () => {
         await expect(endpoint.conformanceClasses).resolves.toEqual([
           'http://www.opengis.net/spec/cql2/0.0/conf/advanced-comparison-operators',
@@ -259,6 +259,1169 @@ describe('OgcApiEndpoint', () => {
           ],
           storageCrs: 'http://www.opengis.net/def/crs/EPSG/0/27700',
           itemCount: 123905,
+        });
+      });
+    });
+    describe('#getCollectionItems', () => {
+      it('returns airports collection items', async () => {
+        await expect(
+          endpoint.getCollectionItems('airports')
+        ).resolves.toStrictEqual([
+          {
+            type: 'Feature',
+            id: 1,
+            geometry: { type: 'Point', coordinates: [-1.2918826, 59.8783475] },
+            properties: { name: 'Sumburgh Airport' },
+          },
+          {
+            type: 'Feature',
+            id: 2,
+            geometry: { type: 'Point', coordinates: [-1.2438161, 60.1918282] },
+            properties: { name: 'Tingwall Airport' },
+          },
+          {
+            type: 'Feature',
+            id: 3,
+            geometry: { type: 'Point', coordinates: [-2.8998525, 58.9579506] },
+            properties: { name: 'Kirkwall Airport' },
+          },
+          {
+            type: 'Feature',
+            id: 4,
+            geometry: { type: 'Point', coordinates: [-6.3295078, 58.2138995] },
+            properties: { name: 'Port-Adhair Steòrnabhaigh/Stornoway Airport' },
+          },
+          {
+            type: 'Feature',
+            id: 5,
+            geometry: { type: 'Point', coordinates: [-3.094033, 58.458363] },
+            properties: { name: "Wick John O'Groats Airport" },
+          },
+          {
+            type: 'Feature',
+            id: 6,
+            geometry: { type: 'Point', coordinates: [-7.3610346, 57.4843261] },
+            properties: {
+              name: 'Port-adhair Bheinn na Faoghla/Benbecula Airport',
+            },
+          },
+          {
+            type: 'Feature',
+            id: 7,
+            geometry: { type: 'Point', coordinates: [-7.4487268, 57.0254269] },
+            properties: { name: 'Port-adhair Bharraigh/Barra Airport' },
+          },
+          {
+            type: 'Feature',
+            id: 8,
+            geometry: { type: 'Point', coordinates: [-4.0493507, 57.5431458] },
+            properties: { name: 'Inverness Airport' },
+          },
+          {
+            type: 'Feature',
+            id: 9,
+            geometry: { type: 'Point', coordinates: [-2.200068, 57.202807] },
+            properties: { name: 'Aberdeen International Airport' },
+          },
+          {
+            type: 'Feature',
+            id: 10,
+            geometry: { type: 'Point', coordinates: [-6.869044, 56.5011563] },
+            properties: { name: 'Tiree Airport' },
+          },
+        ]);
+      });
+      it('returns dutch-metadata collection items', async () => {
+        await expect(
+          endpoint.getCollectionItems('dutch-metadata')
+        ).resolves.toStrictEqual([
+          {
+            id: '35149dfb-31d3-431c-a8bc-12a4034dac48',
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [4.690751953125, 52.358740234375],
+                  [4.690751953125, 52.6333984375],
+                  [5.020341796875, 52.6333984375],
+                  [5.020341796875, 52.358740234375],
+                  [4.690751953125, 52.358740234375],
+                ],
+              ],
+            },
+            properties: {
+              recordCreated: '2021-12-08',
+              recordUpdated: '2022-06-10T01:27:47Z',
+              type: 'dataset',
+              title: 'Kaartboeck 1635',
+              description:
+                'Data uit kaartboeken van de periode 1635 tot 1775. De kaartboeken werden door het waterschap gebruikt om er op toe te zien dat de eigenaren geen water in beslag namen door demping.\nDe percelen op de kaart zijn naar de huidige maatstaven vrij nauwkeurig gemeten en voorzien van een administratie met de eigenaren. bijzondere locaties van molens werven en beroepen worden in de boeken vermeld. Alle 97 kaarten aan een geven een zeer gedetailleerd beeld van de Voorzaan, Nieuwe Haven en de Achterzaan. De bladen Oost en West van de zaan zijn vrij nauwkeurig. De bladen aan de Voorzaan zijn een schetsmatige weergave van de situatie. De kaart van de Nieuwe Haven si weer nauwkeurig te noemen.',
+              providers: [
+                'Team Geo, geo-informatie@zaanstad.nl, Gemeente Zaanstad',
+              ],
+              externalIds: [
+                {
+                  scheme: 'default',
+                  value: '35149dfb-31d3-431c-a8bc-12a4034dac48',
+                },
+              ],
+              themes: [
+                {
+                  concepts: [
+                    'ARGEOLOGIE',
+                    'MONUMENTEN',
+                    'KADASTER',
+                    'KAARTBOEK',
+                    'KAARTBOECK',
+                    'HISTORIE',
+                  ],
+                },
+              ],
+              extent: {
+                spatial: {
+                  bbox: [
+                    [
+                      4.690751953125,
+                      52.358740234375,
+                      5.020341796875,
+                      52.6333984375,
+                    ],
+                  ],
+                  crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                temporal: {
+                  interval: [null, null],
+                  trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+                },
+              },
+            },
+            links: [
+              {
+                href:
+                  'https://maps-intern.zaanstad.gem.local/geoserver/wms?SERVICE=WMS',
+                rel: 'item',
+                title: 'geo:kaartboeck',
+                type: 'OGC:WMS',
+              },
+              {
+                href:
+                  'https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS',
+                rel: 'item',
+                title: 'geo:kaartboeck',
+                type: 'OGC:WFS',
+              },
+              {
+                href:
+                  'https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=geo:kaartboeck&outputFormat=csv',
+                rel: 'item',
+                type: 'download',
+              },
+              {
+                href:
+                  'https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=geo:kaartboeck&outputFormat=shape-zip',
+                rel: 'item',
+                type: 'download',
+              },
+            ],
+          },
+          {
+            id: 'ffffffaa-4087-59ec-9ea7-8416f58e99dd',
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [4.4552947, 52.3348457],
+                  [4.4552947, 53.388444],
+                  [7.135964, 53.388444],
+                  [7.135964, 52.3348457],
+                  [4.4552947, 52.3348457],
+                ],
+              ],
+            },
+            properties: {
+              recordCreated: '2022-06-01',
+              recordUpdated: '2022-06-10T01:27:47Z',
+              type: 'dataset',
+              title: 'Diepteligging onderkant keileem (t.o.v. NAP)',
+              description:
+                'Diepteligging van de onderkant (basis) van keileem in Drenthe, in meters ten opzichte van NAP.',
+              providers: [
+                'Team Gis/Cartografie, post@drenthe.nl, Provincie Drenthe',
+              ],
+              externalIds: [
+                {
+                  scheme: 'default',
+                  value: 'ffffffaa-4087-59ec-9ea7-8416f58e99dd',
+                },
+              ],
+              themes: [
+                {
+                  concepts: [
+                    'beleidsinstrument',
+                    'bodem',
+                    'grondwaterstand',
+                    'landbouw',
+                    'landbouwgrond',
+                    'waterhuishouding',
+                  ],
+                  scheme: null,
+                },
+              ],
+              extent: {
+                spatial: {
+                  bbox: [[4.4552947, 52.3348457, 7.135964, 53.388444]],
+                  crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                temporal: {
+                  interval: [null, null],
+                  trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+                },
+              },
+            },
+            links: [
+              {
+                href:
+                  'https://kaartportaal.drenthe.nl/server/services/GDB_actueel/GBI_KEILEEM_DIEPTE_ONDER_NAP_R/MapServer/WMSServer',
+                rel: 'item',
+                title: '0',
+                type: 'OGC:WMS',
+              },
+            ],
+          },
+          {
+            id: '59352e7f-3792-4e17-bd73-9bba84a98890',
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [4.79, 51.857],
+                  [4.79, 52.305],
+                  [5.63, 52.305],
+                  [5.63, 51.857],
+                  [4.79, 51.857],
+                ],
+              ],
+            },
+            properties: {
+              recordCreated: '2021-06-30',
+              recordUpdated: '2022-06-10T01:27:47Z',
+              type: 'dataset',
+              title: 'Clusters geluid - wegen gecumuleerd',
+              description:
+                'Clusters (omtreklijn) gebaseerd op gemeentegrenzen. Per cluster zijn de aantallen woningen en gevoelige bestemmingen per GES-score geteld. Bij de gevoelige bestemmingen is onderscheid gemaakt in 3 categorien: Ziekenhuizen, Scholen en dagverblijven voor jeugd, Verpleeg en verzorgingshuizen.',
+              providers: ['GIS, GIS@provincie-utrecht.nl, Provincie Utrecht'],
+              externalIds: [
+                {
+                  scheme: 'default',
+                  value: '59352e7f-3792-4e17-bd73-9bba84a98890',
+                },
+              ],
+              themes: [
+                {
+                  concepts: [
+                    'GELUIDHINDER',
+                    'GELUIDSZONES',
+                    'PROVINCIALE WEGEN',
+                    'VERKEERSLAWAAI',
+                    'WET GELUIDHINDER',
+                  ],
+                  scheme: null,
+                },
+                {
+                  concepts: ['Informatief'],
+                  scheme: null,
+                },
+              ],
+              extent: {
+                spatial: {
+                  bbox: [[4.79, 51.857, 5.63, 52.305]],
+                  crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                temporal: {
+                  interval: [null, null],
+                  trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+                },
+              },
+            },
+            links: [
+              {
+                href:
+                  'https://download.geodata-utrecht.nl/download/vector/59352e7f-3792-4e17-bd73-9bba84a98890',
+                rel: 'item',
+                type: 'landingpage',
+              },
+              {
+                href:
+                  'https://services.geodata-utrecht.nl/geoserver/m01_4_overlast_hinder_mgkp/wfs',
+                rel: 'item',
+                title: 'Clusters_geluid_-_wegen_gecumuleerd',
+                type: 'OGC:WFS',
+              },
+              {
+                href:
+                  'https://services.geodata-utrecht.nl/geoserver/m01_4_overlast_hinder_mgkp/wms',
+                rel: 'item',
+                title: 'Clusters_geluid_-_wegen_gecumuleerd',
+                type: 'OGC:WMS',
+              },
+            ],
+          },
+          {
+            id: '0ec79c96-898f-40da-adc7-673eb4749685',
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [4.1407, 52.004],
+                  [4.1407, 52.9215],
+                  [4.8927, 52.9215],
+                  [4.8927, 52.004],
+                  [4.1407, 52.004],
+                ],
+              ],
+            },
+            properties: {
+              recordCreated: '2022-02-02',
+              recordUpdated: '2022-06-10T01:27:47Z',
+              type: 'dataset',
+              title: 'Geesten van Holland',
+              description:
+                "In de dataset 'Geesten' zijn de locaties opgenomen van middeleeuwse akkercomplexen op de strandwallen in Noord- en Zuid-Holland.",
+              providers: [
+                'InfoDesk, info@cultureelerfgoed.nl, Rijksdienst voor het Cultureel Erfgoed',
+              ],
+              externalIds: [
+                {
+                  scheme: 'default',
+                  value: '0ec79c96-898f-40da-adc7-673eb4749685',
+                },
+              ],
+              themes: [
+                {
+                  concepts: [],
+                },
+              ],
+              extent: {
+                spatial: {
+                  bbox: [[4.1407, 52.004, 4.8927, 52.9215]],
+                  crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                temporal: {
+                  interval: [null, null],
+                  trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+                },
+              },
+            },
+            links: [
+              {
+                href:
+                  'https://services.rce.geovoorziening.nl/landschapsatlas/wms?&request=GetCapabilities',
+                rel: 'item',
+                title: 'Geesten',
+              },
+              {
+                href:
+                  'https://services.rce.geovoorziening.nl/landschapsatlas/wfs?&request=GetCapabilities',
+                rel: 'item',
+                title: 'landschapsatlas:Geesten',
+              },
+            ],
+          },
+          {
+            id: '364c5d7a-d6ec-11ea-87d0-0242ac130003',
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [3.2, 50.75],
+                  [3.2, 53.7],
+                  [7.22, 53.7],
+                  [7.22, 50.75],
+                  [3.2, 50.75],
+                ],
+              ],
+            },
+            properties: {
+              recordCreated: '2021-06-18',
+              recordUpdated: '2022-06-10T01:27:47Z',
+              type: 'service',
+              title: 'Grondwaterstandsonderzoek, downloadservice',
+              description:
+                'Gegevens over grondwaterstandsonderzoek (Groundwaterlevel data in het Engels) zijn opgeslagen in de basisregistratie ondergrond (BRO). Het registratieobject grondwaterstandonderzoek bevat de metingen van de variatie in de stand van het grondwater dat in een bekende grondwatermonitoringput met een zekere buis wordt ontsloten.\nMet het monitoren van het grondwater gebeurt al lange tijd, op vele locaties in ons land. Met die informatie is het mogelijk om karakteristieke kenmerken van de beweging van het grondwater vast te stellen, ruimtelijke patronen te herkennen en trendmatige veranderingen te analyseren.\nBelangrijke kenmerken zijn bijvoorbeeld de hoogste en laatste grondwaterstand die in een bepaald gebied zijn te verwachten als gevolg van het jaarlijkse seizoenpatroon. Die kennis is niet alleen van belang voor de landbouw en natuurontwikkeling, maar ook voor het ontwerpen van nieuwe woonwijken en infrastructuur.\nDe meetgegevens geven inzicht in de reactie van het grondwater op  veranderingen zoals de verlaging van een polderpeil, of grondwaterwinning. Op basis van die informatie kunnen voorspellingen worden gedaan over het verloop van de grondwaterstand in de toekomst. Hoe langer de tijdreeksen zijn, des te nauwkeuriger de voorspellingen zijn over het lange termijn gedrag van het grondwater.\nEen van de belangrijke uitdagingen van nu is het voorspellen van de invloed van de klimaatverandering op het grondwatersysteem. Zowel in nationaal als internationaal verband worden richtlijnen ontwikkeld voor een duurzaam beleid en beheer van onze grondwatersystemen.',
+              providers: [
+                'support@broservicedesk.nl, TNO Geologische Dienst Nederland',
+              ],
+              externalIds: [
+                {
+                  scheme: 'default',
+                  value: '364c5d7a-d6ec-11ea-87d0-0242ac130003',
+                },
+              ],
+              themes: [
+                {
+                  concepts: ['infoMapAccessService'],
+                },
+                {
+                  concepts: [
+                    'basisregistratie ondergrond',
+                    'bro',
+                    'GMN',
+                    'grondwatermonitoring',
+                    'grondwatermonitoringnet',
+                    'grondwateronderzoek',
+                    'grondwaterstand',
+                  ],
+                  scheme: null,
+                },
+              ],
+              extent: {
+                spatial: {
+                  bbox: [[3.2, 50.75, 7.22, 53.7]],
+                  crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                temporal: {
+                  interval: [null, null],
+                  trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+                },
+              },
+            },
+            links: [],
+          },
+          {
+            id: '7B40133214B7456CE053D2041EACD771',
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [6.105, 52.601],
+                  [6.105, 53.213],
+                  [7.109, 53.213],
+                  [7.109, 52.601],
+                  [6.105, 52.601],
+                ],
+              ],
+            },
+            properties: {
+              recordCreated: '2022-06-01',
+              recordUpdated: '2022-06-10T01:27:47Z',
+              type: 'dataset',
+              title: 'Hemelhelderheidskaart',
+              description:
+                'Hemelhelderheid Drenthe met kasverlichting gedoofd (2015-2016). De grootheid luminantie (helderheid) kent verschillende eenheden en die worden in de kaart weergegeven. De eenheid candela per vierkante meter is de eenheid die verlichtingsdeskundigen gebruiken om te meten hoeveel licht ergens op straalt. De gebruikte eenheid mcd/m2 is een duizendste cd/m2. De eenheid magnitude wordt gebruikt door sterrenkundigen. Hoe helderder de hemel, hoe hoger het getal in candela per vierkante meter, hoe meer licht er van de hemel komt.',
+              providers: [
+                'Team Gis/Cartografie, post@drenthe.nl, Provincie Drenthe',
+              ],
+              externalIds: [
+                {
+                  scheme: 'default',
+                  value: '7B40133214B7456CE053D2041EACD771',
+                },
+              ],
+              themes: [
+                {
+                  concepts: ['locaties'],
+                  scheme: null,
+                },
+              ],
+              extent: {
+                spatial: {
+                  bbox: [[6.105, 52.601, 7.109, 53.213]],
+                  crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                temporal: {
+                  interval: [null, null],
+                  trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+                },
+              },
+            },
+            links: [
+              {
+                href:
+                  'https://kaartportaal.drenthe.nl/server/services/GDB_actueel/GBI_MILIEU_HEMELHELDERHEID_V/MapServer/WMSServer',
+                rel: 'item',
+                title: '0',
+                type: 'OGC:WMS',
+              },
+              {
+                href:
+                  'https://kaartportaal.drenthe.nl/server/services/GDB_actueel/GBI_MILIEU_HEMELHELDERHEID_V/MapServer/WFSServer',
+                rel: 'item',
+                title: 'esri:Hemelhelderheidskaart',
+                type: 'OGC:WFS',
+              },
+            ],
+          },
+          {
+            id: '1da54925-0085-4972-bdec-47bef653fc16',
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [3.15, 50.6],
+                  [3.15, 53.6],
+                  [7.3, 53.6],
+                  [7.3, 50.6],
+                  [3.15, 50.6],
+                ],
+              ],
+            },
+            properties: {
+              recordCreated: '2020-12-21',
+              recordUpdated: '2022-06-10T01:27:47Z',
+              type: 'service',
+              title: 'WarmteAtlas WMS',
+              description:
+                'Atlas voor kaarten over het warmte gebruik (industrie, glastuinbouw en huishoudens) en potentieel kaarten voor de productie van duurzame warmte en de aanwezigheid van nog niet benutte restwarmte.',
+              providers: [
+                'klantcontact, klantcontact@rvo.nl, Rijksdienst voor Ondernemend Nederland (RvO)',
+              ],
+              externalIds: [
+                {
+                  scheme: 'default',
+                  value: '1da54925-0085-4972-bdec-47bef653fc16',
+                },
+              ],
+              themes: [
+                {
+                  concepts: [
+                    'infoMapAccessService',
+                    'Energie',
+                    'Warmte',
+                    'Biogas',
+                    'Aardwarmte',
+                    'Thermische Energie Oppervlaktewater TEO',
+                    'Warmte Koude Opslag WKO',
+                    'Gebouwde Omgeving',
+                    'Industrie',
+                    'CO2 emissie',
+                    'Glastuinbouw',
+                    'Grote Stook Installaties',
+                    'IBIS Bedrijventerreinen',
+                    'Grote Gebouwen',
+                    'Warmtenetten',
+                    'Aardwarmte',
+                    'Biomassa',
+                    'Energie vraag',
+                    'Woonkernen',
+                    'Kassen',
+                    'WarmteAtlas',
+                  ],
+                },
+                {
+                  concepts: ['Energiebronnen'],
+                  scheme: null,
+                },
+                {
+                  concepts: [
+                    'Energie',
+                    'Warmte',
+                    'Industrie',
+                    'Kassen',
+                    'Bedrijventerreinen',
+                    'Grote Stook Installaties',
+                    'Grote Gebouwen',
+                    'Woonkernen',
+                    'Warmtenetten',
+                    'Warmte Vraag',
+                    'Warmte Potentieel',
+                    'Nationaal',
+                    'Glastuinbouw',
+                    'WarmteAtlas',
+                    'Energie Verbruik',
+                    'Energie',
+                    null,
+                  ],
+                  scheme: null,
+                },
+              ],
+              extent: {
+                spatial: {
+                  bbox: [[3.15, 50.6, 7.3, 53.6]],
+                  crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                temporal: {
+                  interval: [null, null],
+                  trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+                },
+              },
+            },
+            links: [
+              {
+                href: 'https://rvo.b3p.nl/geoserver/WarmteAtlas/wms?',
+                rel: 'item',
+                title: 'WarmteAtlas WMS',
+                type: 'OGC:WMS',
+              },
+            ],
+          },
+          {
+            id: 'efc55744-a8f5-40e1-8d15-1ffa7a018988',
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [3.37087, 50.7539],
+                  [3.37087, 53.4658],
+                  [7.21097, 53.4658],
+                  [7.21097, 50.7539],
+                  [3.37087, 50.7539],
+                ],
+              ],
+            },
+            properties: {
+              recordCreated: '2021-12-22',
+              recordUpdated: '2022-06-10T01:27:47Z',
+              type: 'dataset',
+              title: 'DANK-Delfstofwinning op land: zand, grind en klei',
+              description:
+                'De kaart geeft de geologische winbare hoeveelheid zand, grind en klei weer wanneer er niet meer dan maximaal 5 meter aan deklaag moet worden afgegraven.\n\n                    Voor de productie van veel bouwmaterialen wordt gebruik gemaakt van oppervlaktedelfstoffen. In Nederland is jaarlijks circa 150 miljoen ton aan bouwgrondstoffen nodig. Een deel daarvan komt uit het buitenland, een deel wordt verkregen door hergebruik (15 tot 20 %), maar nog steeds wordt een groot deel verkregen uit primaire winning.\n\n                    Sinds 1900 is de winning van ophoogzand op verschillende locaties uitgevoerd door maaiveldverlaging in het kader van\n                    landbouwkundige verbeteringen (ruilverkaveling).\n                    Sinds de jaren zeventig is er een afname in oppervlakkig ontgronden door toenemende maatschappelijke weerstand en strengere wetgevingen. Zandwinning vindt nu voornamelijk plaats in geconcentreerde winputten. Aanvullend vindt winning plaats middels het "werk met werk maken" principe. Hierin wordt bijvoorbeeld in nieuwbouwprojecten zand gewonnen voor gebruik in het project en tegelijkertijd waterberging gecre\u00eberd.\n                    Voor winning van oppervlaktedelfstoffen is per jaar circa 400 hectare oppervlakte van ons land noodzakelijk. Ongeveer de helft daarvan, circa 200 hectare, blijft achter als diep water. De andere 200 hectare krijgt via herinrichting een nieuwe ruimtelijke bestemming, bijvoorbeeld als natuur- of recreatiegebied. Alternatief is de winning van zand uit het IJsselmeer, de Randmeren en de Noordzee. De winning van grind is vooral voorzien plaats te vinden uit de maaswerken in Limburg.\n                    De winning en reservering van zand en grind zijn bij de wet geregeld en land based winlocaties worden door de provincie aangewezen. De winning van zand en grind legt een ruimtebeslag die enerzijds kan conflicteren met ander gebruik, anderzijds kan ook de winning samengaan met inrichtingsvraagstukken zoals het geven van ruimte voor de rivieren en tijdelijke waterberging.',
+              providers: [
+                'atlasnatuurlijkkapitaal@rivm.nl, Atlas Natuurlijk Kapitaal',
+              ],
+              externalIds: [
+                {
+                  scheme: 'default',
+                  value: 'efc55744-a8f5-40e1-8d15-1ffa7a018988',
+                },
+              ],
+              themes: [
+                {
+                  concepts: ['winning zand grid diepte nederland'],
+                },
+              ],
+              extent: {
+                spatial: {
+                  bbox: [[3.37087, 50.7539, 7.21097, 53.4658]],
+                  crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                temporal: {
+                  interval: [null, null],
+                  trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+                },
+              },
+            },
+            links: [
+              {
+                href: 'http://data.rivm.nl/geo/ank/wms?',
+                rel: 'item',
+                title:
+                  'd022_delftstofwinning_op_land_en_in_binnenwateren_rivier',
+                type: 'OGC:WMS',
+              },
+              {
+                href:
+                  'https://data.rivm.nl/meta/srv/api/records/efc55744-a8f5-40e1-8d15-1ffa7a018988/attachments/DANK022_delfstofwinning_op_land_en_in_binnenwateren_rivier.zip',
+                rel: 'item',
+                title:
+                  'DANK022_delfstofwinning_op_land_en_in_binnenwateren_rivier.zip',
+                type: 'download',
+              },
+            ],
+          },
+          {
+            id: '826735d1-1467-4888-9829-61019c033431',
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [4.690751953125, 52.358740234375],
+                  [4.690751953125, 52.6333984375],
+                  [5.020341796875, 52.6333984375],
+                  [5.020341796875, 52.358740234375],
+                  [4.690751953125, 52.358740234375],
+                ],
+              ],
+            },
+            properties: {
+              recordCreated: '2021-11-17',
+              recordUpdated: '2022-06-10T01:27:47Z',
+              type: 'dataset',
+              title: 'Luchtfoto 2018',
+              description:
+                'Een luchtfoto is een afbeelding van een gedeelte van het aardoppervlak, gefotografeerd van uit een hoog standpunt los van het aardoppervlak, veelal vanuit een luchtvaartuig.',
+              providers: [
+                'Team Geo, geo-informatie@zaanstad.nl, Gemeente Zaanstad',
+              ],
+              externalIds: [
+                {
+                  scheme: 'default',
+                  value: '826735d1-1467-4888-9829-61019c033431',
+                },
+              ],
+              themes: [
+                {
+                  concepts: [
+                    'FOTO',
+                    'LUCHTFOTO',
+                    'REFERENTIEKAART',
+                    'TOPOGRAFIE',
+                    '2018',
+                    'LUFO',
+                    null,
+                  ],
+                },
+              ],
+              extent: {
+                spatial: {
+                  bbox: [
+                    [
+                      4.690751953125,
+                      52.358740234375,
+                      5.020341796875,
+                      52.6333984375,
+                    ],
+                  ],
+                  crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                temporal: {
+                  interval: [null, null],
+                  trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+                },
+              },
+            },
+            links: [
+              {
+                href: 'https://tiles.zaanstad.nl/mapproxy/service?SERVICE=WMS',
+                rel: 'item',
+                title: 'Lufo2018-kleur',
+                type: 'OGC:WMS',
+              },
+              {
+                href: 'https://tiles.zaanstad.nl/mapproxy/service?SERVICE=WFS',
+                rel: 'item',
+                title: 'Lufo2018-kleur',
+                type: 'OGC:WFS',
+              },
+              {
+                href:
+                  'https://tiles.zaanstad.nl/mapproxy/service?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=Lufo2018-kleur&outputFormat=csv',
+                rel: 'item',
+                title: 'CSV',
+                type: 'download',
+              },
+              {
+                href:
+                  'https://tiles.zaanstad.nl/mapproxy/service?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=Lufo2018-kleur&outputFormat=shape-zip',
+                rel: 'item',
+                title: 'Shape-zip',
+                type: 'download',
+              },
+            ],
+          },
+          {
+            id: 'b7d2fd24-8cd8-4965-a997-69eb1a987b5a',
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [3.37087, 50.7539],
+                  [3.37087, 53.4658],
+                  [7.21097, 53.4658],
+                  [7.21097, 50.7539],
+                  [3.37087, 50.7539],
+                ],
+              ],
+            },
+            properties: {
+              recordCreated: '2019-04-16',
+              recordUpdated: '2022-06-10T01:27:47Z',
+              type: 'dataset',
+              title: 'Zonpotentie velden',
+              description:
+                'In deze kaartlaag zijn denkbare locaties voor zonnepanelen in veldopstelling aangegeven. Het gaat hier om kleine terreinen (tussen 0,5 en 1,0 hectare), middelgrote terreinen (tussen 1,0 en 3,0 hectare) en grote terreinen (3,0 hectare en groter). Te zien zijn gras- en akkerlanden buiten de bebouwing, exclusief gebieden die tot Natura2000 behoren.\n\nVoor iedere locatie is aangegeven wat het plaatsbare schaduwvrije zon-PV-vermogen is, uitgaande van schaduwvrije velden en 0,65 MWp vermogen per hectare grond.\n\nTevens is de verwachte jaarlijkse kWh-opbrengst aangeduid (900 kWh/kWp), evenals het aantal huishoudens dat van groene stroom kan worden voorzien met deze opbrengst (3.300 kWh/huishouden).\nDe selectie van locaties is expliciet niet gemaakt op basis van politieke voorkeuren of richtlijnen van gemeenten dan wel provincies, bijvoorbeeld met betrekking tot de (on)wenselijkheid van zonnevelden op landbouwgronden.\n\nToekomstige uitbreiding (1)\nGewerkt wordt aan een weergave van de kaartlaag met daarin relevante netdata verwerkt. Concreet gaat dit dan om de afstanden van denkbare locaties tot aan het middenspanningsnet of het dichtstbijzijnde onder-, regel- of schakelstation.\n\nToekomstige uitbreiding (2)\nTevens wordt gewerkt aan weergave van de kaartlaag met daarin zoninstralingsdata op de denkbare locaties voor zonnepanelen in veldopstelling. Hiermee wordt het schaduweffect van objecten op en rond het terrein inzichtelijk gemaakt.',
+              providers: ['atlasleefomgeving@rivm.nl, Atlas Leefomgeving'],
+              externalIds: [
+                {
+                  scheme: 'default',
+                  value: 'b7d2fd24-8cd8-4965-a997-69eb1a987b5a',
+                },
+              ],
+              themes: [
+                {
+                  concepts: ['zonnepanelen', 'energie'],
+                  scheme: null,
+                },
+              ],
+              extent: {
+                spatial: {
+                  bbox: [[3.37087, 50.7539, 7.21097, 53.4658]],
+                  crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+                },
+                temporal: {
+                  interval: [null, null],
+                  trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+                },
+              },
+            },
+            links: [
+              {
+                href: 'http://geodata.rivm.nl/geoserver/nea/wms?',
+                rel: 'item',
+                title: 'Greenspread_20181101_v_zonnevelden',
+                type: 'OGC:WMS',
+              },
+              {
+                href: 'http://geodata.rivm.nl/geoserver/nea/wms?',
+                rel: 'item',
+                title: 'Greenspread_20181101_v_zonnevelden',
+                type: 'OGC:WFS',
+              },
+            ],
+          },
+        ]);
+      });
+      it('returns roads_national collection items', async () => {
+        await expect(
+          endpoint.getCollectionItems('roads_national')
+        ).resolves.toStrictEqual([
+          {
+            type: 'Feature',
+            id: 1,
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-3.7146553, 58.0895513],
+                [-3.7171409, 58.0885901],
+              ],
+            },
+            properties: { type: 'Primary', number: 'A9', level: 0 },
+          },
+          {
+            type: 'Feature',
+            id: 2,
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-3.7461507, 58.0813773],
+                [-3.7469084, 58.0810599],
+                [-3.7506235, 58.0802469],
+              ],
+            },
+            properties: { type: 'Primary', number: 'A9', level: 0 },
+          },
+          {
+            type: 'Feature',
+            id: 3,
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-3.7450719, 58.0818592],
+                [-3.7461507, 58.0813773],
+              ],
+            },
+            properties: { type: 'Primary', number: 'A9', level: 0 },
+          },
+          {
+            type: 'Feature',
+            id: 4,
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-3.7380837, 58.0842815],
+                [-3.7401187, 58.08358],
+                [-3.7420469, 58.0831224],
+                [-3.7437685, 58.0826047],
+                [-3.7450719, 58.0818592],
+              ],
+            },
+            properties: { type: 'Primary', number: 'A9', level: 0 },
+          },
+          {
+            type: 'Feature',
+            id: 5,
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-3.7373997, 58.0845154],
+                [-3.7380837, 58.0842815],
+              ],
+            },
+            properties: { type: 'Primary', number: 'A9', level: 0 },
+          },
+          {
+            type: 'Feature',
+            id: 6,
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-3.7171409, 58.0885901],
+                [-3.7174653, 58.0884718],
+                [-3.7195617, 58.087902],
+                [-3.721399, 58.0875031],
+                [-3.7256251, 58.0868944],
+                [-3.7289353, 58.0862476],
+                [-3.7321928, 58.0859159],
+                [-3.7333858, 58.0856841],
+                [-3.7353467, 58.0851992],
+                [-3.7373997, 58.0845154],
+              ],
+            },
+            properties: { type: 'Primary', number: 'A9', level: 0 },
+          },
+          {
+            type: 'Feature',
+            id: 7,
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-3.7638606, 58.0763091],
+                [-3.7704891, 58.0745642],
+              ],
+            },
+            properties: { type: 'Primary', number: 'A9', level: 0 },
+          },
+          {
+            type: 'Feature',
+            id: 8,
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-3.7099634, 58.0917321],
+                [-3.71127, 58.0910318],
+                [-3.7127532, 58.0903683],
+                [-3.7146553, 58.0895513],
+              ],
+            },
+            properties: { type: 'Primary', number: 'A9', level: 0 },
+          },
+          {
+            type: 'Feature',
+            id: 9,
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-3.7036866, 58.0950811],
+                [-3.7038614, 58.0950389],
+                [-3.7056711, 58.0945655],
+                [-3.7064724, 58.0942942],
+                [-3.7072678, 58.0938973],
+                [-3.707711, 58.0935859],
+                [-3.7088797, 58.0924832],
+                [-3.7099634, 58.0917321],
+              ],
+            },
+            properties: { type: 'Primary', number: 'A9', level: 0 },
+          },
+          {
+            type: 'Feature',
+            id: 10,
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [-3.7036866, 58.0950811],
+                [-3.7029109, 58.0952652],
+              ],
+            },
+            properties: { type: 'Primary', number: 'A9', level: 0 },
+          },
+        ]);
+      });
+    });
+    describe('#getCollectionItem', () => {
+      it('returns one airports collection item', async () => {
+        await expect(
+          endpoint.getCollectionItem('airports', '1')
+        ).resolves.toStrictEqual({
+          geometry: {
+            coordinates: [-1.2918826, 59.8783475],
+            type: 'Point',
+          },
+          id: 1,
+          links: [
+            {
+              href:
+                'https://demo.ldproxy.net/zoomstack/collections/airports/items/1?f=json',
+              rel: 'self',
+              title: 'This document',
+              type: 'application/geo+json',
+            },
+            {
+              href:
+                'https://demo.ldproxy.net/zoomstack/collections/airports/items/1?f=jsonfgc',
+              rel: 'alternate',
+              title: 'This document as JSON-FG (GeoJSON Compatibility Mode)',
+              type: 'application/vnd.ogc.fg+json;compatibility=geojson',
+            },
+            {
+              href:
+                'https://demo.ldproxy.net/zoomstack/collections/airports/items/1?f=fgb',
+              rel: 'alternate',
+              title: 'This document as FlatGeobuf',
+              type: 'application/flatgeobuf',
+            },
+            {
+              href:
+                'https://demo.ldproxy.net/zoomstack/collections/airports/items/1?f=html',
+              rel: 'alternate',
+              title: 'This document as HTML',
+              type: 'text/html',
+            },
+            {
+              href:
+                'https://demo.ldproxy.net/zoomstack/collections/airports/items/1?f=jsonfg',
+              rel: 'alternate',
+              title: 'This document as JSON-FG',
+              type: 'application/vnd.ogc.fg+json',
+            },
+            {
+              href:
+                'https://demo.ldproxy.net/zoomstack/collections/airports?f=json',
+              rel: 'collection',
+              title: 'The collection the feature belongs to',
+              type: 'application/json',
+            },
+          ],
+          properties: {
+            name: 'Sumburgh Airport',
+          },
+          type: 'Feature',
+        });
+      });
+      it('returns dutch-metadata collection item', async () => {
+        await expect(
+          endpoint.getCollectionItem(
+            'dutch-metadata',
+            '35149dfb-31d3-431c-a8bc-12a4034dac48'
+          )
+        ).resolves.toStrictEqual({
+          geometry: {
+            coordinates: [
+              [
+                [4.690751953125, 52.358740234375],
+                [4.690751953125, 52.6333984375],
+                [5.020341796875, 52.6333984375],
+                [5.020341796875, 52.358740234375],
+                [4.690751953125, 52.358740234375],
+              ],
+            ],
+            type: 'Polygon',
+          },
+          id: '35149dfb-31d3-431c-a8bc-12a4034dac48',
+          links: [
+            {
+              href:
+                'https://maps-intern.zaanstad.gem.local/geoserver/wms?SERVICE=WMS',
+              rel: 'item',
+              title: 'geo:kaartboeck',
+              type: 'OGC:WMS',
+            },
+            {
+              href:
+                'https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS',
+              rel: 'item',
+              title: 'geo:kaartboeck',
+              type: 'OGC:WFS',
+            },
+            {
+              href:
+                'https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=geo:kaartboeck&outputFormat=csv',
+              rel: 'item',
+              type: 'download',
+            },
+            {
+              href:
+                'https://maps-intern.zaanstad.gem.local/geoserver/wfs?SERVICE=WFS&version=1.0.0&request=GetFeature&typeName=geo:kaartboeck&outputFormat=shape-zip',
+              rel: 'item',
+              type: 'download',
+            },
+            {
+              href: 'https://demo.pygeoapi.io/master?f=json',
+              rel: 'root',
+              title: 'The landing page of this server as JSON',
+              type: 'application/json',
+            },
+            {
+              href: 'https://demo.pygeoapi.io/master?f=html',
+              rel: 'root',
+              title: 'The landing page of this server as HTML',
+              type: 'text/html',
+            },
+            {
+              href:
+                'https://demo.pygeoapi.io/master/collections/dutch-metadata/items/35149dfb-31d3-431c-a8bc-12a4034dac48?f=json',
+              rel: 'self',
+              title: 'This document as GeoJSON',
+              type: 'application/geo+json',
+            },
+            {
+              href:
+                'https://demo.pygeoapi.io/master/collections/dutch-metadata/items/35149dfb-31d3-431c-a8bc-12a4034dac48?f=jsonld',
+              rel: 'alternate',
+              title: 'This document as RDF (JSON-LD)',
+              type: 'application/ld+json',
+            },
+            {
+              href:
+                'https://demo.pygeoapi.io/master/collections/dutch-metadata/items/35149dfb-31d3-431c-a8bc-12a4034dac48?f=html',
+              rel: 'alternate',
+              title: 'This document as HTML',
+              type: 'text/html',
+            },
+            {
+              href:
+                'https://demo.pygeoapi.io/master/collections/dutch-metadata',
+              rel: 'collection',
+              title: 'Sample metadata records from Dutch Nationaal georegister',
+              type: 'application/json',
+            },
+          ],
+          properties: {
+            description:
+              'Data uit kaartboeken van de periode 1635 tot 1775. De kaartboeken werden door het waterschap gebruikt om er op toe te zien dat de eigenaren geen water in beslag namen door demping.\nDe percelen op de kaart zijn naar de huidige maatstaven vrij nauwkeurig gemeten en voorzien van een administratie met de eigenaren. bijzondere locaties van molens werven en beroepen worden in de boeken vermeld. Alle 97 kaarten aan een geven een zeer gedetailleerd beeld van de Voorzaan, Nieuwe Haven en de Achterzaan. De bladen Oost en West van de zaan zijn vrij nauwkeurig. De bladen aan de Voorzaan zijn een schetsmatige weergave van de situatie. De kaart van de Nieuwe Haven si weer nauwkeurig te noemen.',
+            extent: {
+              spatial: {
+                bbox: [
+                  [
+                    4.690751953125,
+                    52.358740234375,
+                    5.020341796875,
+                    52.6333984375,
+                  ],
+                ],
+                crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+              },
+              temporal: {
+                interval: [null, null],
+                trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+              },
+            },
+            externalIds: [
+              {
+                scheme: 'default',
+                value: '35149dfb-31d3-431c-a8bc-12a4034dac48',
+              },
+            ],
+            providers: [
+              'Team Geo, geo-informatie@zaanstad.nl, Gemeente Zaanstad',
+            ],
+            recordCreated: '2021-12-08',
+            recordUpdated: '2022-06-10T01:27:47Z',
+            themes: [
+              {
+                concepts: [
+                  'ARGEOLOGIE',
+                  'MONUMENTEN',
+                  'KADASTER',
+                  'KAARTBOEK',
+                  'KAARTBOECK',
+                  'HISTORIE',
+                ],
+              },
+            ],
+            title: 'Kaartboeck 1635',
+            type: 'dataset',
+          },
+          type: 'Feature',
         });
       });
     });

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -1,0 +1,266 @@
+import OgcApiEndpoint from './endpoint';
+import { readFile } from 'fs/promises';
+import * as path from 'path';
+
+const FIXTURES_ROOT = path.join(__dirname, '../../fixtures/ogc-api');
+
+// setup fetch to read local fixtures
+beforeAll(() => {
+  window.fetch = (urlOrInfo) =>
+    new Promise(async (resolve) => {
+      const url = new URL(
+        urlOrInfo instanceof URL || typeof urlOrInfo === 'string'
+          ? urlOrInfo
+          : urlOrInfo.url
+      );
+      const queryPath = url.pathname;
+      const format = url.searchParams.get('f') || 'html';
+      const filePath = `${path.join(FIXTURES_ROOT, queryPath)}.${format}`;
+      const contents = await readFile(filePath, {
+        encoding: 'utf8',
+      });
+      resolve({
+        ok: true,
+        headers: new Headers(),
+        json: () => Promise.resolve(JSON.parse(contents)),
+      } as Response);
+    });
+});
+
+describe('OgcApiEndpoint', () => {
+  let endpoint: OgcApiEndpoint;
+  describe('nominal case', () => {
+    beforeEach(() => {
+      endpoint = new OgcApiEndpoint('http://local/sample-data');
+    });
+    describe('#info', () => {
+      it('returns endpoint info', async () => {
+        await expect(endpoint.info).resolves.toEqual({
+          title: 'OS Open Zoomstack',
+          description:
+            'OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.',
+          attribution:
+            'Contains OS data © Crown copyright and database right 2021.',
+        });
+      });
+    });
+    describe('#conformanceClasses', () => {
+      it('returns conformance classes', async () => {
+        await expect(endpoint.conformanceClasses).resolves.toEqual([
+          'http://www.opengis.net/spec/cql2/0.0/conf/advanced-comparison-operators',
+          'http://www.opengis.net/spec/cql2/0.0/conf/array-operators',
+          'http://www.opengis.net/spec/cql2/0.0/conf/basic-cql2',
+          'http://www.opengis.net/spec/cql2/0.0/conf/basic-spatial-operators',
+          'http://www.opengis.net/spec/cql2/0.0/conf/case-insensitive-comparison',
+          'http://www.opengis.net/spec/cql2/0.0/conf/cql2-json',
+          'http://www.opengis.net/spec/cql2/0.0/conf/cql2-text',
+          'http://www.opengis.net/spec/cql2/0.0/conf/property-property',
+          'http://www.opengis.net/spec/cql2/0.0/conf/spatial-operators',
+          'http://www.opengis.net/spec/cql2/0.0/conf/temporal-operators',
+          'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core',
+          'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/html',
+          'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json',
+          'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30',
+          'http://www.opengis.net/spec/ogcapi-common-2/0.0/conf/collections',
+          'http://www.opengis.net/spec/ogcapi-common-2/0.0/conf/html',
+          'http://www.opengis.net/spec/ogcapi-common-2/0.0/conf/json',
+          'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
+          'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson',
+          'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html',
+          'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30',
+          'http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs',
+          'http://www.opengis.net/spec/ogcapi-features-3/0.0/conf/features-filter',
+          'http://www.opengis.net/spec/ogcapi-features-3/0.0/conf/filter',
+          'http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/core',
+          'http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/manage-styles',
+          'http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/mapbox-styles',
+          'http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/sld-10',
+          'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core',
+          'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/dataset-tilesets',
+          'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt',
+          'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset',
+          'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list',
+          'http://www.opengis.net/spec/tms/2.0/conf/json-tilematrixset',
+          'http://www.opengis.net/spec/tms/2.0/conf/json-tilematrixsetlimits',
+          'http://www.opengis.net/spec/tms/2.0/conf/json-tilesetmetadata',
+          'http://www.opengis.net/spec/tms/2.0/conf/tilematrixset',
+          'http://www.opengis.net/spec/tms/2.0/conf/tilematrixsetlimits',
+          'http://www.opengis.net/spec/tms/2.0/conf/tilesetmetadata',
+          'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/html',
+          'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/json',
+          'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/core',
+          'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/opensearch',
+          'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/sorting',
+        ]);
+      });
+    });
+    describe('#allCollections', () => {
+      it('returns collection ids', async () => {
+        await expect(endpoint.allCollections).resolves.toEqual([
+          'airports',
+          'boundaries',
+          'contours',
+          'district_buildings',
+          'etl',
+          'foreshore',
+          'greenspace',
+          'land',
+          'local_buildings',
+          'names',
+          'national_parks',
+          'rail',
+          'railway_stations',
+          'roads_local',
+          'roads_national',
+          'roads_regional',
+          'sites',
+          'surfacewater',
+          'urban_areas',
+          'waterlines',
+          'woodland',
+          'dutch-metadata',
+        ]);
+      });
+    });
+    describe('#featureCollections', () => {
+      it('returns collection ids', async () => {
+        await expect(endpoint.featureCollections).resolves.toEqual([
+          'airports',
+          'boundaries',
+          'contours',
+          'district_buildings',
+          'etl',
+          'foreshore',
+          'greenspace',
+          'land',
+          'local_buildings',
+          'names',
+          'national_parks',
+          'rail',
+          'railway_stations',
+          'roads_local',
+          'roads_national',
+          'roads_regional',
+          'sites',
+          'surfacewater',
+          'urban_areas',
+          'waterlines',
+          'woodland',
+        ]);
+      });
+    });
+    describe('#recordCollections', () => {
+      it('returns collection ids', async () => {
+        await expect(endpoint.recordCollections).resolves.toEqual([
+          'dutch-metadata',
+        ]);
+      });
+    });
+    describe('#hasTiles', () => {
+      it('returns true', async () => {
+        await expect(endpoint.hasTiles).resolves.toBe(true);
+      });
+    });
+    describe('#hasStyles', () => {
+      it('returns true', async () => {
+        await expect(endpoint.hasStyles).resolves.toBe(true);
+      });
+    });
+    describe('#hasFeatures', () => {
+      it('returns true', async () => {
+        await expect(endpoint.hasFeatures).resolves.toBe(true);
+      });
+    });
+    describe('#hasRecords', () => {
+      it('returns true', async () => {
+        await expect(endpoint.hasRecords).resolves.toBe(true);
+      });
+    });
+    describe('#getCollectionInfo', () => {
+      it('returns airports collection info', async () => {
+        await expect(
+          endpoint.getCollectionInfo('airports')
+        ).resolves.toStrictEqual({
+          title: 'Airports',
+          description:
+            'A centre point for all major airports including a name.',
+          id: 'airports',
+          extent: {
+            spatial: {
+              bbox: [
+                [
+                  -7.942759150065165,
+                  49.901607895996534,
+                  1.9957427933628138,
+                  60.133709755754,
+                ],
+              ],
+              crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+            },
+          },
+          itemType: 'feature',
+          crs: [
+            'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+            'http://www.opengis.net/def/crs/EPSG/0/27700',
+            'http://www.opengis.net/def/crs/EPSG/0/4258',
+            'http://www.opengis.net/def/crs/EPSG/0/4326',
+            'http://www.opengis.net/def/crs/EPSG/0/3857',
+          ],
+          storageCrs: 'http://www.opengis.net/def/crs/EPSG/0/27700',
+          itemCount: 46,
+        });
+      });
+      it('returns dutch-metadata collection info', async () => {
+        await expect(
+          endpoint.getCollectionInfo('dutch-metadata')
+        ).resolves.toStrictEqual({
+          id: 'dutch-metadata',
+          title: 'Sample metadata records from Dutch Nationaal georegister',
+          description:
+            'Sample metadata records from Dutch Nationaal georegister',
+          keywords: ['netherlands', 'open data', 'georegister'],
+          extent: {
+            spatial: {
+              bbox: [[3.37, 50.75, 7.21, 53.47]],
+              crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+            },
+          },
+          itemType: 'record',
+        });
+      });
+      it('returns roads_national collection info', async () => {
+        await expect(
+          endpoint.getCollectionInfo('roads_national')
+        ).resolves.toStrictEqual({
+          title: 'National Roads',
+          description:
+            'Lines representing the road network. A road is defined as a metalled way for vehicles.',
+          id: 'roads_national',
+          extent: {
+            spatial: {
+              bbox: [
+                [
+                  -6.4956758012099645,
+                  50.08021976237488,
+                  2.383883951687144,
+                  58.54688148276149,
+                ],
+              ],
+              crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+            },
+          },
+          itemType: 'feature',
+          crs: [
+            'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+            'http://www.opengis.net/def/crs/EPSG/0/27700',
+            'http://www.opengis.net/def/crs/EPSG/0/4258',
+            'http://www.opengis.net/def/crs/EPSG/0/4326',
+            'http://www.opengis.net/def/crs/EPSG/0/3857',
+          ],
+          storageCrs: 'http://www.opengis.net/def/crs/EPSG/0/27700',
+          itemCount: 123905,
+        });
+      });
+    });
+  });
+});

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -1,0 +1,82 @@
+import {
+  checkHasFeatures,
+  checkHasRecords,
+  checkStyleConformance,
+  checkTileConformance,
+  parseCollectionInfo,
+  parseCollections,
+  parseConformance,
+  parseEndpointInfo,
+} from './info';
+import {
+  ConformanceClass,
+  OgcApiCollectionInfo,
+  OgcApiCollectionItem,
+  OgcApiDocument,
+  OgcApiEndpointInfo,
+} from './model';
+import { fetchLink, fetchRoot } from './link-utils';
+import { EndpointError } from '../shared/errors';
+
+export default class OgcApiEndpoint {
+  private root = fetchRoot(this.baseUrl);
+  private conformance = this.root.then((root) =>
+    fetchLink(root, 'conformance')
+  );
+  private data = this.root.then((root) => fetchLink(root, 'data'));
+
+  constructor(private baseUrl: string) {}
+
+  get info(): Promise<OgcApiEndpointInfo> {
+    return this.root.then(parseEndpointInfo);
+  }
+  get conformanceClasses(): Promise<ConformanceClass[]> {
+    return this.conformance.then(parseConformance);
+  }
+  get allCollections(): Promise<string[]> {
+    return this.data.then(parseCollections());
+  }
+  get recordCollections(): Promise<string[]> {
+    return Promise.all([this.data, this.hasRecords])
+      .then(([data, hasRecords]) => (hasRecords ? data : { collections: [] }))
+      .then(parseCollections('record'));
+  }
+  get featureCollections(): Promise<string[]> {
+    return Promise.all([this.data, this.hasFeatures])
+      .then(([data, hasFeatures]) => (hasFeatures ? data : { collections: [] }))
+      .then(parseCollections('feature'));
+  }
+  get hasTiles(): Promise<boolean> {
+    return this.conformanceClasses.then(checkTileConformance);
+  }
+  get hasStyles(): Promise<boolean> {
+    return this.conformanceClasses.then(checkStyleConformance);
+  }
+  get hasFeatures(): Promise<boolean> {
+    return Promise.all([
+      this.data.then((data) => data.collections),
+      this.conformanceClasses,
+    ]).then(checkHasFeatures);
+  }
+  get hasRecords(): Promise<boolean> {
+    return Promise.all([
+      this.data.then((data) => data.collections),
+      this.conformanceClasses,
+    ]).then(checkHasRecords);
+  }
+  getCollectionInfo(collectionId: string): Promise<OgcApiCollectionInfo> {
+    return Promise.all([this.allCollections, this.data])
+      .then(([collections, data]) => {
+        if (collections.indexOf(collectionId) === -1)
+          throw new EndpointError(`Collection not found: ${collectionId}`);
+        return (data.collections as OgcApiDocument[]).find(
+          (collection) => collection.id === collectionId
+        );
+      })
+      .then((collection) => fetchLink(collection, 'self'))
+      .then(parseCollectionInfo);
+  }
+  getCollectionItems(collectionId: string): Promise<OgcApiCollectionItem[]> {
+    return Promise.resolve([]);
+  }
+}

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -21,9 +21,11 @@ import { EndpointError } from '../shared/errors';
 export default class OgcApiEndpoint {
   private root = fetchRoot(this.baseUrl);
   private conformance = this.root.then((root) =>
-    fetchLink(root, 'conformance')
+    fetchLink(root, 'conformance', this.baseUrl)
   );
-  private data = this.root.then((root) => fetchLink(root, 'data'));
+  private data = this.root.then((root) =>
+    fetchLink(root, 'data', this.baseUrl)
+  );
 
   constructor(private baseUrl: string) {}
 
@@ -73,7 +75,7 @@ export default class OgcApiEndpoint {
           (collection) => collection.id === collectionId
         );
       })
-      .then((collection) => fetchLink(collection, 'self'));
+      .then((collection) => fetchLink(collection, 'self', this.baseUrl));
   }
   getCollectionInfo(collectionId: string): Promise<OgcApiCollectionInfo> {
     return this.getCollectionDocument(collectionId).then(parseCollectionInfo);
@@ -90,7 +92,7 @@ export default class OgcApiEndpoint {
     return this.getCollectionDocument(collectionId)
       .then((collectionDoc) => {
         const url = new URL(
-          getLinkUrl(collectionDoc, 'items'),
+          getLinkUrl(collectionDoc, 'items', this.baseUrl),
           window.location.toString()
         );
         url.searchParams.set('limit', limit.toString());
@@ -115,7 +117,7 @@ export default class OgcApiEndpoint {
     return this.getCollectionDocument(collectionId)
       .then((collectionDoc) => {
         const url = new URL(
-          getLinkUrl(collectionDoc, 'items'),
+          getLinkUrl(collectionDoc, 'items', this.baseUrl),
           window.location.toString()
         );
         url.pathname += `/${itemId}`;

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -1,0 +1,80 @@
+import {
+  ConformanceClass,
+  OgcApiCollectionInfo,
+  OgcApiDocument,
+  OgcApiEndpointInfo,
+} from './model';
+
+export function parseEndpointInfo(rootDoc: OgcApiDocument): OgcApiEndpointInfo {
+  return {
+    title: rootDoc.title as string,
+    description: rootDoc.description as string,
+    attribution: rootDoc.attribution as string,
+  };
+}
+
+export function parseConformance(doc: OgcApiDocument): ConformanceClass[] {
+  return doc.conformsTo as string[];
+}
+
+export function parseCollections(
+  itemType: 'record' | 'feature' | null = null
+): (doc: OgcApiDocument) => ConformanceClass[] {
+  return (doc: OgcApiDocument) =>
+    (doc.collections as OgcApiCollectionInfo[])
+      .filter(
+        (collection) => itemType === null || collection.itemType === itemType
+      )
+      .map((collection) => collection.id as string);
+}
+
+export function checkTileConformance(conformance: ConformanceClass[]) {
+  return (
+    conformance.indexOf(
+      'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core'
+    ) > -1
+  );
+}
+
+export function checkStyleConformance(conformance: ConformanceClass[]) {
+  return (
+    conformance.indexOf(
+      'http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/core'
+    ) > -1
+  );
+}
+
+export function checkHasRecords([collections, conformance]: [
+  OgcApiCollectionInfo[],
+  ConformanceClass[]
+]) {
+  const classes = [
+    'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/record-core',
+    'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/record-collection',
+    'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/record-api',
+  ];
+  return (
+    (classes.every((confClass) => conformance.indexOf(confClass) > -1) ||
+      conformance.indexOf(
+        'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/core'
+      ) > -1) &&
+    collections.some((collection) => collection.itemType === 'record')
+  );
+}
+
+export function checkHasFeatures([collections, conformance]: [
+  OgcApiCollectionInfo[],
+  ConformanceClass[]
+]) {
+  return (
+    conformance.indexOf(
+      'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core'
+    ) > -1 &&
+    collections.some((collection) => collection.itemType === 'feature')
+  );
+}
+
+export function parseCollectionInfo(doc: OgcApiDocument): OgcApiCollectionInfo {
+  const { links, ...props } = doc;
+  return (props as unknown) as OgcApiCollectionInfo;
+}

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -9,14 +9,14 @@ export function fetchDocument(url: string): Promise<OgcApiDocument> {
   }).then((resp) => resp.json());
 }
 
-// look for root document?
 export function fetchRoot(url: string) {
   return fetchDocument(url);
 }
 
 export function getLinkUrl(
   doc: OgcApiDocument,
-  relType: string | string[]
+  relType: string | string[],
+  baseUrl?: string
 ): string {
   const links = doc.links.filter((link) =>
     Array.isArray(relType)
@@ -24,11 +24,18 @@ export function getLinkUrl(
       : link.rel === relType
   );
   if (!links.length) return null;
-  return links[0].href;
+  return new URL(
+    links[0].href,
+    baseUrl || window.location.toString()
+  ).toString();
 }
 
-export function fetchLink(doc: OgcApiDocument, relType: string | string[]) {
-  const url = getLinkUrl(doc, relType);
+export function fetchLink(
+  doc: OgcApiDocument,
+  relType: string | string[],
+  baseUrl?: string
+) {
+  const url = getLinkUrl(doc, relType, baseUrl);
   if (!url)
     return Promise.reject(
       new EndpointError(`Could not find link with type: ${relType}`)

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -1,0 +1,26 @@
+import { OgcApiDocument } from './model';
+
+function fetchDocument(url: string): Promise<OgcApiDocument> {
+  const urlObj = new URL(url, window.location.toString());
+  urlObj.searchParams.set('f', 'json');
+  return fetch(urlObj.toString(), {
+    headers: { Accept: 'application/json' },
+  }).then((resp) => resp.json());
+}
+
+// look for root document?
+export function fetchRoot(url: string) {
+  return fetchDocument(url);
+}
+
+export function fetchLink(doc: OgcApiDocument, relType: string | string[]) {
+  const links = doc.links.filter((link) =>
+    Array.isArray(relType)
+      ? relType.indexOf(link.rel) > -1
+      : link.rel === relType
+  );
+  if (!links.length) return null;
+  return fetchDocument(links[0].href);
+}
+
+// navigate through links

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -1,6 +1,7 @@
 import { OgcApiDocument } from './model';
+import { EndpointError } from '../shared/errors';
 
-function fetchDocument(url: string): Promise<OgcApiDocument> {
+export function fetchDocument(url: string): Promise<OgcApiDocument> {
   const urlObj = new URL(url, window.location.toString());
   urlObj.searchParams.set('f', 'json');
   return fetch(urlObj.toString(), {
@@ -13,14 +14,24 @@ export function fetchRoot(url: string) {
   return fetchDocument(url);
 }
 
-export function fetchLink(doc: OgcApiDocument, relType: string | string[]) {
+export function getLinkUrl(
+  doc: OgcApiDocument,
+  relType: string | string[]
+): string {
   const links = doc.links.filter((link) =>
     Array.isArray(relType)
       ? relType.indexOf(link.rel) > -1
       : link.rel === relType
   );
   if (!links.length) return null;
-  return fetchDocument(links[0].href);
+  return links[0].href;
 }
 
-// navigate through links
+export function fetchLink(doc: OgcApiDocument, relType: string | string[]) {
+  const url = getLinkUrl(doc, relType);
+  if (!url)
+    return Promise.reject(
+      new EndpointError(`Could not find link with type: ${relType}`)
+    );
+  return fetchDocument(url);
+}

--- a/src/ogc-api/model.ts
+++ b/src/ogc-api/model.ts
@@ -1,0 +1,46 @@
+import { BoundingBox, CrsCode } from '../shared/models';
+
+export type ConformanceClass = string;
+
+export interface OgcApiEndpointInfo {
+  title: string;
+  description?: string;
+  attribution?: string;
+}
+
+export interface OgcApiCollectionInfo {
+  title: string;
+  description: string;
+  id: string;
+  itemType: 'feature' | 'record';
+  crs: ['#/crs'];
+  storageCrs?: CrsCode;
+  itemCount: number;
+  keywords?: string[];
+  language?: string; // ISO2
+  updated?: Date;
+  extent?: BoundingBox;
+  publisher?: {
+    individualName: string;
+    organizationName: string;
+    positionName: string;
+    contactInfo: {
+      phone: string;
+      email: {
+        work: string;
+      };
+    };
+  };
+  license?: string;
+}
+
+export interface OgcApiCollectionItem {}
+
+export type OgcApiDocument = {
+  links: {
+    rel: string;
+    type: string;
+    title: string;
+    href: string;
+  }[];
+} & Record<string, unknown>;

--- a/src/ogc-api/model.ts
+++ b/src/ogc-api/model.ts
@@ -1,3 +1,4 @@
+import { Feature } from 'geojson';
 import { BoundingBox, CrsCode } from '../shared/models';
 
 export type ConformanceClass = string;
@@ -34,7 +35,7 @@ export interface OgcApiCollectionInfo {
   license?: string;
 }
 
-export interface OgcApiCollectionItem {}
+export type OgcApiCollectionItem = Feature | unknown;
 
 export type OgcApiDocument = {
   links: {


### PR DESCRIPTION
What it does:
- check conformance classes to establish support for tiles, styles, records, features
- explore feature collections and record collections
- query collection items as GeoJSON

Not done yet:
- look at advertised sortables and queryables
- better test coverage
- explore styles and tiles
- handle other data/metadata formats