### PR TITLE
Added a method to get all the tile collections

### DIFF
--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -166,6 +166,11 @@ describe('OgcApiEndpoint', () => {
         ]);
       });
     });
+    describe('#tileCollections', () => {
+      it('returns collection ids', async () => {
+        await expect(endpoint.tileCollections).resolves.toEqual([]);
+      });
+    });
     describe('#hasTiles', () => {
       it('returns true', async () => {
         await expect(endpoint.hasTiles).resolves.toBe(true);

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -97,7 +97,7 @@ export default class OgcApiEndpoint {
   get recordCollections(): Promise<string[]> {
     return Promise.all([this.data, this.hasRecords])
       .then(([data, hasRecords]) => (hasRecords ? data : { collections: [] }))
-      .then(parseCollections('record'));
+      .then(parseCollections('record', null));
   }
 
   /**
@@ -106,7 +106,16 @@ export default class OgcApiEndpoint {
   get featureCollections(): Promise<string[]> {
     return Promise.all([this.data, this.hasFeatures])
       .then(([data, hasFeatures]) => (hasFeatures ? data : { collections: [] }))
-      .then(parseCollections('feature'));
+      .then(parseCollections('feature', null));
+  }
+
+  /**
+   * A Promise which resolves to an array of tile collection identifiers as strings.
+   */
+  get tileCollections(): Promise<string[]> {
+    return Promise.all([this.data, this.hasTiles])
+      .then(([data, hasTiles]) => (hasTiles ? data : { collections: [] }))
+      .then(parseCollections(null, 'vector'));
   }
 
   /**

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -36,12 +36,15 @@ export function parseConformance(doc: OgcApiDocument): ConformanceClass[] {
 }
 
 export function parseCollections(
-  itemType: 'record' | 'feature' | null = null
+  itemType: 'record' | 'feature' | null = null,
+  dataType: 'vector' | null = null
 ): (doc: OgcApiDocument) => string[] {
   return (doc: OgcApiDocument) =>
     (doc.collections as OgcApiCollectionInfo[])
       .filter(
-        (collection) => itemType === null || collection.itemType === itemType
+        (collection) =>
+          (itemType === null || collection.itemType === itemType) &&
+          (dataType === null || collection.dataType === dataType)
       )
       .map((collection) => collection.id as string);
 }

--- a/src/ogc-api/model.ts
+++ b/src/ogc-api/model.ts
@@ -31,6 +31,7 @@ export interface OgcApiCollectionInfo {
   description: string;
   id: string;
   itemType: 'feature' | 'record';
+  dataType: 'vector';
   formats: MimeType[];
   crs: CrsCode[];
   storageCrs?: CrsCode;


### PR DESCRIPTION
This Pull Request introduces the following:

- Addition of a new Promise, `tileCollections`, to the OgcApiEndpoint class in the `src/ogc-api/endpoint.ts` file. This Promise resolves to an array of tile collection identifiers as strings. It checks if the endpoint offers tiles and if so, it parses the collections to return only those of type 'vector'.
- Update to the `parseCollections` function in the `src/ogc-api/info.ts file`. It filters and maps collections based on item type and data type. Now it includes the 'vector' data type in its filtering process, enhancing its ability to parse collections of vector data types.

