### PR TITLE
Improve root path lookup for OGC API endpoint

### DIFF
--- a/fixtures/ogc-api/sample-data-2.json
+++ b/fixtures/ogc-api/sample-data-2.json
@@ -1,0 +1,36 @@
+{
+  "title": "geOrchestra Data API",
+  "description": "data-api provides an API to access datas",
+  "links": [
+    {
+      "href": "https://my.server.org/sample-data-2/",
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document as JSON"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/conformance",
+      "rel": "conformance",
+      "type": "application/json",
+      "title": "Conformance"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections",
+      "rel": "data",
+      "type": "application/json",
+      "title": "Collections"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/../v3/api-docs",
+      "rel": "service-desc",
+      "type": "application/vnd.oai.openapi+json;version=3.0",
+      "title": "OpenAPI definition in JSON format"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/../swagger-ui/index.html",
+      "rel": "service-doc",
+      "type": "text/html",
+      "title": "OpenAPI definition in HTML format"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data-2/collections.json
+++ b/fixtures/ogc-api/sample-data-2/collections.json
@@ -1,0 +1,474 @@
+{
+  "collections": [
+    {
+      "id": "aires-covoiturage",
+      "title": "aires-covoiturage",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "aires-covoiturage"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=shapefile&limit=-1",
+          "rel": "enclosure",
+          "type": "application/x-shapefile",
+          "title": "Bulk download (Esri Shapefile)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "feature",
+      "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84", "EPSG:4326"]
+    },
+    {
+      "id": "antenne",
+      "title": "antenne",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/antenne/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "antenne"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/antenne/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/antenne/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/antenne/items?f=shapefile&limit=-1",
+          "rel": "enclosure",
+          "type": "application/x-shapefile",
+          "title": "Bulk download (Esri Shapefile)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/antenne/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/antenne/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "feature",
+      "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84", "EPSG:2154"]
+    },
+    {
+      "id": "armoires",
+      "title": "armoires",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/armoires/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "armoires"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/armoires/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/armoires/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/armoires/items?f=shapefile&limit=-1",
+          "rel": "enclosure",
+          "type": "application/x-shapefile",
+          "title": "Bulk download (Esri Shapefile)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/armoires/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/armoires/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "feature",
+      "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84", "EPSG:4326"]
+    },
+    {
+      "id": "boite_branchement",
+      "title": "boite_branchement",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/boite_branchement/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "boite_branchement"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/boite_branchement/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/boite_branchement/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/boite_branchement/items?f=shapefile&limit=-1",
+          "rel": "enclosure",
+          "type": "application/x-shapefile",
+          "title": "Bulk download (Esri Shapefile)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/boite_branchement/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/boite_branchement/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "feature",
+      "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84", "EPSG:2154"]
+    },
+    {
+      "id": "collecteur_gravitaire",
+      "title": "collecteur_gravitaire",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/collecteur_gravitaire/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "collecteur_gravitaire"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/collecteur_gravitaire/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/collecteur_gravitaire/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/collecteur_gravitaire/items?f=shapefile&limit=-1",
+          "rel": "enclosure",
+          "type": "application/x-shapefile",
+          "title": "Bulk download (Esri Shapefile)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/collecteur_gravitaire/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/collecteur_gravitaire/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "feature",
+      "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84", "EPSG:2154"]
+    },
+    {
+      "id": "equipements_culturels",
+      "title": "equipements_culturels",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/equipements_culturels/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "equipements_culturels"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/equipements_culturels/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/equipements_culturels/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/equipements_culturels/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/equipements_culturels/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "record"
+    },
+    {
+      "id": "etalab_parcelle",
+      "title": "etalab_parcelle",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/etalab_parcelle/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "etalab_parcelle"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/etalab_parcelle/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/etalab_parcelle/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/etalab_parcelle/items?f=shapefile&limit=-1",
+          "rel": "enclosure",
+          "type": "application/x-shapefile",
+          "title": "Bulk download (Esri Shapefile)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/etalab_parcelle/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/etalab_parcelle/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "feature",
+      "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84", "EPSG:2154"]
+    },
+    {
+      "id": "gendarmeries",
+      "title": "gendarmeries",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/gendarmeries/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "gendarmeries"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/gendarmeries/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/gendarmeries/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/gendarmeries/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/gendarmeries/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "record"
+    },
+    {
+      "id": "mel_commune_llh",
+      "title": "mel_commune_llh",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/mel_commune_llh/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "mel_commune_llh"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/mel_commune_llh/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/mel_commune_llh/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/mel_commune_llh/items?f=shapefile&limit=-1",
+          "rel": "enclosure",
+          "type": "application/x-shapefile",
+          "title": "Bulk download (Esri Shapefile)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/mel_commune_llh/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/mel_commune_llh/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "feature",
+      "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84", "EPSG:2154"]
+    },
+    {
+      "id": "ne_10m_admin_0_countries",
+      "title": "ne_10m_admin_0_countries",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ne_10m_admin_0_countries/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "ne_10m_admin_0_countries"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ne_10m_admin_0_countries/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ne_10m_admin_0_countries/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ne_10m_admin_0_countries/items?f=shapefile&limit=-1",
+          "rel": "enclosure",
+          "type": "application/x-shapefile",
+          "title": "Bulk download (Esri Shapefile)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ne_10m_admin_0_countries/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ne_10m_admin_0_countries/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "feature",
+      "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84", "EPSG:4326"]
+    },
+    {
+      "id": "ouvrage_surfacique",
+      "title": "ouvrage_surfacique",
+      "links": [
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ouvrage_surfacique/items?f=geojson",
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "ouvrage_surfacique"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ouvrage_surfacique/items?f=json&limit=-1",
+          "rel": "enclosure",
+          "type": "application/json",
+          "title": "Bulk download (JSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ouvrage_surfacique/items?f=geojson&limit=-1",
+          "rel": "enclosure",
+          "type": "application/geo+json",
+          "title": "Bulk download (GeoJSON)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ouvrage_surfacique/items?f=shapefile&limit=-1",
+          "rel": "enclosure",
+          "type": "application/x-shapefile",
+          "title": "Bulk download (Esri Shapefile)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ouvrage_surfacique/items?f=csv&limit=-1",
+          "rel": "enclosure",
+          "type": "text/csv;charset=UTF-8",
+          "title": "Bulk download (Comma Separated Values)"
+        },
+        {
+          "href": "https://my.server.org/sample-data-2/collections/ouvrage_surfacique/items?f=ooxml&limit=-1",
+          "rel": "enclosure",
+          "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "title": "Bulk download (Excel 2007 / OOXML)"
+        }
+      ],
+      "itemType": "feature",
+      "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84", "EPSG:2154"]
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data-2/collections/aires-covoiturage.json
+++ b/fixtures/ogc-api/sample-data-2/collections/aires-covoiturage.json
@@ -1,0 +1,44 @@
+{
+  "id": "aires-covoiturage",
+  "title": "aires-covoiturage",
+  "links": [
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=geojson",
+      "rel": "items",
+      "type": "application/geo+json",
+      "title": "aires-covoiturage"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=json&limit=-1",
+      "rel": "enclosure",
+      "type": "application/json",
+      "title": "Bulk download (JSON)"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=geojson&limit=-1",
+      "rel": "enclosure",
+      "type": "application/geo+json",
+      "title": "Bulk download (GeoJSON)"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=shapefile&limit=-1",
+      "rel": "enclosure",
+      "type": "application/x-shapefile",
+      "title": "Bulk download (Esri Shapefile)"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=csv&limit=-1",
+      "rel": "enclosure",
+      "type": "text/csv;charset=UTF-8",
+      "title": "Bulk download (Comma Separated Values)"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=ooxml&limit=-1",
+      "rel": "enclosure",
+      "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "title": "Bulk download (Excel 2007 / OOXML)"
+    }
+  ],
+  "itemType": "feature",
+  "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84", "EPSG:4326"]
+}

--- a/fixtures/ogc-api/sample-data-2/collections/aires-covoiturage/items.json
+++ b/fixtures/ogc-api/sample-data-2/collections/aires-covoiturage/items.json
@@ -1,0 +1,376 @@
+{
+  "type": "FeatureCollection",
+  "timeStamp": "2024-04-22T16:13:04.314635813Z",
+  "numberMatched": 19,
+  "numberReturned": 10,
+  "features": [
+    {
+      "type": "Feature",
+      "@typeName": "aires-covoiturage",
+      "@id": "1",
+      "geometry": {
+        "type": "Point",
+        "@name": "the_geom",
+        "@srs": "EPSG:4326",
+        "coordinates": [3.1357683190685193, 50.754946172495444]
+      },
+      "properties": {
+        "id_lieu": "59508-C-001",
+        "nom_lieu": "CIT",
+        "ad_lieu": "CIT Avenue de l'Europe, 59223 Roncq",
+        "com_lieu": "RONCQ",
+        "insee": 59508.0,
+        "type": "Parking",
+        "date_maj": "2020-08-01 02:00:00+02:00",
+        "ouvert": "true",
+        "source": 2.4590041e8,
+        "xlong": 3.135088,
+        "ylat": 50.751979,
+        "nbre_pl": 49.0,
+        "nbre_pmr": 1.0,
+        "duree": "",
+        "horaires": "",
+        "proprio": "Aire amenagee par la MEL",
+        "lumiere": "",
+        "comm": "",
+        "velo_pl": "",
+        "nb_bornes": ""
+      }
+    },
+    {
+      "type": "Feature",
+      "@typeName": "aires-covoiturage",
+      "@id": "2",
+      "geometry": {
+        "type": "Point",
+        "@name": "the_geom",
+        "@srs": "EPSG:4326",
+        "coordinates": [2.954210661381357, 50.73591302198993]
+      },
+      "properties": {
+        "id_lieu": "59173-C-001",
+        "nom_lieu": "Bellevue",
+        "ad_lieu": "1 Domaine de la Bellevue, 59890 Deulemont",
+        "com_lieu": "DEULEMONT",
+        "insee": 59173.0,
+        "type": "Parking",
+        "date_maj": "2019-08-29 02:00:00+02:00",
+        "ouvert": "true",
+        "source": 2.4590041e8,
+        "xlong": 2.9542959322,
+        "ylat": 50.7359050653,
+        "nbre_pl": 10.0,
+        "nbre_pmr": 1.0,
+        "duree": "",
+        "horaires": "",
+        "proprio": "Aire amenagee par la MEL",
+        "lumiere": "",
+        "comm": "",
+        "velo_pl": "",
+        "nb_bornes": ""
+      }
+    },
+    {
+      "type": "Feature",
+      "@typeName": "aires-covoiturage",
+      "@id": "3",
+      "geometry": {
+        "type": "Point",
+        "@name": "the_geom",
+        "@srs": "EPSG:4326",
+        "coordinates": [2.905488724207134, 50.668981775292224]
+      },
+      "properties": {
+        "id_lieu": "59143-C-001",
+        "nom_lieu": "Birchington",
+        "ad_lieu": "401 Route Nationale, 59930 La Chapelle-d'Armentieres",
+        "com_lieu": "LA CHAPELLE D'ARMENTIERES",
+        "insee": 59143.0,
+        "type": "Aire de covoiturage",
+        "date_maj": "2019-08-29 02:00:00+02:00",
+        "ouvert": "true",
+        "source": 2.4590041e8,
+        "xlong": 2.9053705079,
+        "ylat": 50.6696197055,
+        "nbre_pl": 53.0,
+        "nbre_pmr": 2.0,
+        "duree": "",
+        "horaires": "",
+        "proprio": "Aire amenagee par la MEL",
+        "lumiere": "",
+        "comm": "",
+        "velo_pl": "",
+        "nb_bornes": ""
+      }
+    },
+    {
+      "type": "Feature",
+      "@typeName": "aires-covoiturage",
+      "@id": "4",
+      "geometry": {
+        "type": "Point",
+        "@name": "the_geom",
+        "@srs": "EPSG:4326",
+        "coordinates": [3.0534896632801045, 50.75305283212758]
+      },
+      "properties": {
+        "id_lieu": "59656-C-001",
+        "nom_lieu": "Haut Cornet",
+        "ad_lieu": "Boulevard de la Lys, 59117 Wervicq Sud",
+        "com_lieu": "WERVICQ-SUD",
+        "insee": 59656.0,
+        "type": "Aire de covoiturage",
+        "date_maj": "2020-08-01 02:00:00+02:00",
+        "ouvert": "true",
+        "source": 2.4590041e8,
+        "xlong": 3.052046,
+        "ylat": 50.753217,
+        "nbre_pl": 28.0,
+        "nbre_pmr": 2.0,
+        "duree": "",
+        "horaires": "",
+        "proprio": "Aire amenagee par la MEL",
+        "lumiere": "",
+        "comm": "",
+        "velo_pl": "",
+        "nb_bornes": ""
+      }
+    },
+    {
+      "type": "Feature",
+      "@typeName": "aires-covoiturage",
+      "@id": "5",
+      "geometry": {
+        "type": "Point",
+        "@name": "the_geom",
+        "@srs": "EPSG:4326",
+        "coordinates": [3.082628412204827, 50.581063179093086]
+      },
+      "properties": {
+        "id_lieu": "59220-C-001",
+        "nom_lieu": "Centre Commercial",
+        "ad_lieu": "Centre Commercial Auchan,  59155 Faches Thumesnil",
+        "com_lieu": "FACHES-THUMESNIL",
+        "insee": 59220.0,
+        "type": "Supermarche",
+        "date_maj": "2020-08-01 02:00:00+02:00",
+        "ouvert": "true",
+        "source": 2.4590041e8,
+        "xlong": 3.083038,
+        "ylat": 50.582269,
+        "nbre_pl": 34.0,
+        "nbre_pmr": null,
+        "duree": "",
+        "horaires": "",
+        "proprio": "Partenariat AUCHAN et MEL",
+        "lumiere": "",
+        "comm": "",
+        "velo_pl": "",
+        "nb_bornes": ""
+      }
+    },
+    {
+      "type": "Feature",
+      "@typeName": "aires-covoiturage",
+      "@id": "6",
+      "geometry": {
+        "type": "Point",
+        "@name": "the_geom",
+        "@srs": "EPSG:4326",
+        "coordinates": [2.838448766230576, 50.54249938763095]
+      },
+      "properties": {
+        "id_lieu": "59550-C-001",
+        "nom_lieu": "Gare",
+        "ad_lieu": "92 rue Jules Ferry, D141, 59496 Salome",
+        "com_lieu": "SALOME",
+        "insee": 59550.0,
+        "type": "Parking",
+        "date_maj": "2020-08-09 02:00:00+02:00",
+        "ouvert": "true",
+        "source": 2.4590041e8,
+        "xlong": 2.8384107791,
+        "ylat": 50.542594446,
+        "nbre_pl": 4.0,
+        "nbre_pmr": 0.0,
+        "duree": "",
+        "horaires": "",
+        "proprio": "Aire amenagee par la MEL",
+        "lumiere": "",
+        "comm": "",
+        "velo_pl": "",
+        "nb_bornes": ""
+      }
+    },
+    {
+      "type": "Feature",
+      "@typeName": "aires-covoiturage",
+      "@id": "7",
+      "geometry": {
+        "type": "Point",
+        "@name": "the_geom",
+        "@srs": "EPSG:4326",
+        "coordinates": [3.1638432206296834, 50.75611189926129]
+      },
+      "properties": {
+        "id_lieu": "59426-C-001",
+        "nom_lieu": "Rocheville",
+        "ad_lieu": "24 Rue du Vertuquet, 59960 Neuville-en-Ferrain",
+        "com_lieu": "NEUVILLE-EN-FERRAIN",
+        "insee": 59426.0,
+        "type": "Parking",
+        "date_maj": "2019-08-29 02:00:00+02:00",
+        "ouvert": "true",
+        "source": 2.4590041e8,
+        "xlong": 3.163904009,
+        "ylat": 50.7561291145,
+        "nbre_pl": 14.0,
+        "nbre_pmr": 0.0,
+        "duree": "",
+        "horaires": "",
+        "proprio": "Aire amenagee par la MEL",
+        "lumiere": "",
+        "comm": "",
+        "velo_pl": "",
+        "nb_bornes": ""
+      }
+    },
+    {
+      "type": "Feature",
+      "@typeName": "aires-covoiturage",
+      "@id": "8",
+      "geometry": {
+        "type": "Point",
+        "@name": "the_geom",
+        "@srs": "EPSG:4326",
+        "coordinates": [3.1349350190442946, 50.62895038854565]
+      },
+      "properties": {
+        "id_lieu": "59009-C-001",
+        "nom_lieu": "Palacium",
+        "ad_lieu": "Avenue du Pont de Bois, 59650 Villeneuve d'Ascq",
+        "com_lieu": "VILLENEUVE D'ASCQ",
+        "insee": 59009.0,
+        "type": "Parking",
+        "date_maj": "2020-08-09 02:00:00+02:00",
+        "ouvert": "true",
+        "source": 2.4590041e8,
+        "xlong": 3.1347821842,
+        "ylat": 50.6281655379,
+        "nbre_pl": 15.0,
+        "nbre_pmr": null,
+        "duree": "",
+        "horaires": "",
+        "proprio": "Aire amenagee par la MEL",
+        "lumiere": "",
+        "comm": "",
+        "velo_pl": "",
+        "nb_bornes": ""
+      }
+    },
+    {
+      "type": "Feature",
+      "@typeName": "aires-covoiturage",
+      "@id": "9",
+      "geometry": {
+        "type": "Point",
+        "@name": "the_geom",
+        "@srs": "EPSG:4326",
+        "coordinates": [2.9517943739393564, 50.60689170093367]
+      },
+      "properties": {
+        "id_lieu": "",
+        "nom_lieu": "La Colle",
+        "ad_lieu": "2 Rue de l'Égalité, 59320 Hallennes-lez-Haubourdin",
+        "com_lieu": "HALLENNES-LEZ-HAUBOURDIN",
+        "insee": 59320.0,
+        "type": "Aire de covoiturage",
+        "date_maj": "2021-12-22 01:00:00+01:00",
+        "ouvert": "true",
+        "source": null,
+        "xlong": 2.951905,
+        "ylat": 50.606907,
+        "nbre_pl": 10.0,
+        "nbre_pmr": 1.0,
+        "duree": "",
+        "horaires": "",
+        "proprio": "Aire amenagee par la MEL",
+        "lumiere": "",
+        "comm": "",
+        "velo_pl": "",
+        "nb_bornes": ""
+      }
+    },
+    {
+      "type": "Feature",
+      "@typeName": "aires-covoiturage",
+      "@id": "10",
+      "geometry": {
+        "type": "Point",
+        "@name": "the_geom",
+        "@srs": "EPSG:4326",
+        "coordinates": [3.0831245801213734, 50.6201191251297]
+      },
+      "properties": {
+        "id_lieu": "59350-C-001",
+        "nom_lieu": "Petit Maroc",
+        "ad_lieu": "B'Twin Village, Rue du Professeur Langevin, 59000 Lille",
+        "com_lieu": "LILLE",
+        "insee": 59350.0,
+        "type": "Parking",
+        "date_maj": "2020-08-09 02:00:00+02:00",
+        "ouvert": "true",
+        "source": 2.4590041e8,
+        "xlong": 3.0833456182,
+        "ylat": 50.6201221014,
+        "nbre_pl": 15.0,
+        "nbre_pmr": null,
+        "duree": "",
+        "horaires": "",
+        "proprio": "Partenariat DECATHLON et MEL",
+        "lumiere": "",
+        "comm": "",
+        "velo_pl": "",
+        "nb_bornes": ""
+      }
+    }
+  ],
+  "links": [
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items",
+      "rel": "self",
+      "type": "application/geo+json",
+      "title": "This document"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=geojson&offset=10&limit=10",
+      "rel": "next",
+      "type": "application/geo+json",
+      "title": "Next page"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=json",
+      "rel": "alternate",
+      "type": "application/json",
+      "title": "This document as JSON"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=shapefile",
+      "rel": "alternate",
+      "type": "application/x-shapefile",
+      "title": "This document as Esri Shapefile"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=csv",
+      "rel": "alternate",
+      "type": "text/csv;charset=UTF-8",
+      "title": "This document as Comma Separated Values"
+    },
+    {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=ooxml",
+      "rel": "alternate",
+      "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "title": "This document as Excel 2007 / OOXML"
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data-2/conformance.json
+++ b/fixtures/ogc-api/sample-data-2/conformance.json
@@ -1,0 +1,18 @@
+{
+  "conformsTo": [
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
+    "http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs",
+    "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
+    "http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/schemas",
+    "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+    "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables-query-parameters",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-features-5/1.0/req/core-roles-features",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html"
+  ]
+}

--- a/fixtures/ogc-api/sample-data/notjson.json
+++ b/fixtures/ogc-api/sample-data/notjson.json
@@ -1,0 +1,1 @@
+hello world

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -21,9 +21,9 @@ beforeAll(() => {
     } catch (e) {
       return {
         ok: false,
-        status: 400,
+        status: 404,
         headers: new Headers(),
-        json: () => Promise.resolve({ links: [] }),
+        json: () => Promise.resolve(JSON.parse('missing')),
       } as Response;
     }
     const contents = await readFile(filePath, {
@@ -32,7 +32,10 @@ beforeAll(() => {
     return {
       ok: true,
       headers: new Headers(),
-      json: () => Promise.resolve(JSON.parse(contents)),
+      json: () =>
+        new Promise((resolve) => {
+          resolve(JSON.parse(contents));
+        }),
     } as Response;
   };
 });
@@ -1535,14 +1538,14 @@ describe('OgcApiEndpoint', () => {
   });
   describe('a failure happens while parsing the endpoint capabilities', () => {
     beforeEach(() => {
-      endpoint = new OgcApiEndpoint('http://local/sample-data/blargz'); // invalid path
+      endpoint = new OgcApiEndpoint('http://local/sample-data/notjson'); // not actually json
     });
     describe('#info', () => {
       it('throws an explicit error', async () => {
         await expect(endpoint.info).rejects.toEqual(
           new EndpointError(
             `The endpoint appears non-conforming, the following error was encountered:
-Could not find link with type: data,http://www.opengis.net/def/rel/ogc/1.0/data`
+The document at http://local/sample-data/notjson?f=json does not appear to be valid JSON.`
           )
         );
       });
@@ -1629,9 +1632,76 @@ Could not find link with type: data,http://www.opengis.net/def/rel/ogc/1.0/data`
     it('throws an explicit error', async () => {
       await expect(endpoint.info).rejects.toEqual(
         new EndpointError(
-          `Could not find the root document, this might not be a valid OGC API endpoint`
+          `The endpoint appears non-conforming, the following error was encountered:
+Could not find a root JSON document containing both a link with rel='data' and a link with rel='conformance'.`
         )
       );
+    });
+  });
+  describe('on a non-existing link', () => {
+    beforeEach(() => {
+      endpoint = new OgcApiEndpoint('http://local/nonexisting');
+    });
+    it('throws an explicit error', async () => {
+      await expect(endpoint.info).rejects.toEqual(
+        new EndpointError(
+          `The endpoint appears non-conforming, the following error was encountered:
+The document at http://local/nonexisting?f=json could not be fetched.`
+        )
+      );
+    });
+  });
+
+  describe('alternate implementation', () => {
+    describe('nominal case', () => {
+      beforeEach(() => {
+        endpoint = new OgcApiEndpoint('http://local/sample-data-2/collections');
+      });
+      describe('#info', () => {
+        it('returns endpoint info', async () => {
+          await expect(endpoint.info).resolves.toEqual({
+            description: 'data-api provides an API to access datas',
+            title: 'geOrchestra Data API',
+          });
+        });
+      });
+      describe('#conformanceClasses', () => {
+        it('returns conformance classes', async () => {
+          await expect(endpoint.conformanceClasses).resolves.toEqual([
+            'http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30',
+            'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json',
+            'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
+            'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30',
+            'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page',
+            'http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs',
+            'http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections',
+            'http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/schemas',
+            'http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables',
+            'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson',
+            'http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables-query-parameters',
+            'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core',
+            'http://www.opengis.net/spec/ogcapi-features-5/1.0/req/core-roles-features',
+            'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html',
+          ]);
+        });
+      });
+      describe('#allCollections', () => {
+        it('returns collection ids', async () => {
+          await expect(endpoint.allCollections).resolves.toEqual([
+            'aires-covoiturage',
+            'antenne',
+            'armoires',
+            'boite_branchement',
+            'collecteur_gravitaire',
+            'equipements_culturels',
+            'etalab_parcelle',
+            'gendarmeries',
+            'mel_commune_llh',
+            'ne_10m_admin_0_countries',
+            'ouvrage_surfacique',
+          ]);
+        });
+      });
     });
   });
 });

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -40,7 +40,10 @@ export default class OgcApiEndpoint {
    * documents inside the endpoint, such as `/collections`, `/collections/items` etc.
    */
   constructor(private baseUrl: string) {
-    this.root = fetchRoot(this.baseUrl);
+    this.root = fetchRoot(this.baseUrl).catch((e) => {
+      throw new Error(`The endpoint appears non-conforming, the following error was encountered:
+${e.message}`);
+    });
     this.conformance = this.root
       .then((root) =>
         fetchLink(

--- a/src/ogc-api/link-utils.spec.ts
+++ b/src/ogc-api/link-utils.spec.ts
@@ -1,0 +1,22 @@
+import { getParentPath } from './link-utils.js';
+
+describe('link utils', () => {
+  describe('getParentPath', () => {
+    it('should return null if no parent path', () => {
+      expect(getParentPath('http://example.com')).toBeNull();
+    });
+    it('should return null if parent path is /', () => {
+      expect(getParentPath('http://example.com/foo')).toBeNull();
+    });
+    it('should return the parent path', () => {
+      expect(getParentPath('http://example.com/foo/bar')).toBe(
+        'http://example.com/foo'
+      );
+    });
+    it('should ignore a trailing slash', () => {
+      expect(getParentPath('http://example.com/foo/bar/')).toBe(
+        'http://example.com/foo'
+      );
+    });
+  });
+});


### PR DESCRIPTION
When using the `OgcApiEndpoint` ogc-client will look for the root path of the endpoint by going up one level in the URL until it finds a JSON document that looks like the root path.

This PR:
* clarifies the error given back by the library when encountering an issue during the root path lookup: either a 404 was received, invalid JSON was received, missing rel types etc.
* makes adaptations to have the library work for another implementation of the standard (geOrchestra Data Api)
* makes it so that ogc-client will add a trailing slash when querying the root path of an endpoint; this is because in some cases (e.g. a webapp deployed on a context) not including a trailing slash might result in a 404

Tests and fixtures were added for all this.