### PR TITLE
OGC API: misc improvements

### DIFF
--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -51,8 +51,16 @@ beforeAll(() => {
   };
 });
 
+jest.useFakeTimers();
+
 describe('OgcApiEndpoint', () => {
   let endpoint: OgcApiEndpoint;
+
+  afterEach(async () => {
+    // this will exhaust all microtasks, effectively preventing rejected promises from leaking between tests
+    await jest.runAllTimersAsync();
+  });
+
   describe('nominal case', () => {
     beforeEach(() => {
       endpoint = new OgcApiEndpoint('http://local/sample-data/');
@@ -1549,10 +1557,11 @@ describe('OgcApiEndpoint', () => {
   });
   describe('a failure happens while parsing the endpoint capabilities', () => {
     beforeEach(() => {
-      endpoint = new OgcApiEndpoint('http://local/sample-data/notjson'); // not actually json
+      // endpoint = new OgcApiEndpoint('http://local/sample-data/notjson'); // not actually json
     });
     describe('#info', () => {
       it('throws an explicit error', async () => {
+        endpoint = new OgcApiEndpoint('http://local/sample-data/notjson'); // not actually json
         await expect(endpoint.info).rejects.toEqual(
           new EndpointError(
             `The endpoint appears non-conforming, the following error was encountered:

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -1713,6 +1713,21 @@ The document at http://local/nonexisting?f=json could not be fetched.`
           ]);
         });
       });
+      describe('#getCollectionInfo', () => {
+        it('returns a collection info', async () => {
+          await expect(
+            endpoint.getCollectionInfo('aires-covoiturage')
+          ).resolves.toStrictEqual({
+            crs: ['http://www.opengis.net/def/crs/OGC/1.3/CRS84', 'EPSG:4326'],
+            formats: ['application/geo+json'],
+            id: 'aires-covoiturage',
+            itemType: 'feature',
+            queryables: [],
+            sortables: [],
+            title: 'aires-covoiturage',
+          });
+        });
+      });
     });
   });
 });

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -224,6 +224,7 @@ describe('OgcApiEndpoint', () => {
             'application/vnd.ogc.fg+json;compatibility=geojson',
             'text/html',
           ],
+          bulkDownloadLinks: {},
           extent: {
             spatial: {
               bbox: [
@@ -274,6 +275,7 @@ describe('OgcApiEndpoint', () => {
           description:
             'Sample metadata records from Dutch Nationaal georegister',
           formats: ['application/geo+json', 'application/ld+json', 'text/html'],
+          bulkDownloadLinks: {},
           keywords: ['netherlands', 'open data', 'georegister'],
           extent: {
             spatial: {
@@ -351,6 +353,7 @@ describe('OgcApiEndpoint', () => {
             'application/vnd.ogc.fg+json;compatibility=geojson',
             'text/html',
           ],
+          bulkDownloadLinks: {},
           extent: {
             spatial: {
               bbox: [
@@ -1729,6 +1732,18 @@ The document at http://local/nonexisting?f=json could not be fetched.`
           ).resolves.toStrictEqual({
             crs: ['http://www.opengis.net/def/crs/OGC/1.3/CRS84', 'EPSG:4326'],
             formats: ['application/geo+json'],
+            bulkDownloadLinks: {
+              'application/geo+json':
+                'https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=geojson&limit=-1',
+              'application/json':
+                'https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=json&limit=-1',
+              'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+                'https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=ooxml&limit=-1',
+              'application/x-shapefile':
+                'https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=shapefile&limit=-1',
+              'text/csv;charset=UTF-8':
+                'https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=csv&limit=-1',
+            },
             id: 'aires-covoiturage',
             itemType: 'feature',
             queryables: [],

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -102,7 +102,13 @@ export function parseBaseCollectionInfo(
   const formats = links
     .filter((link) => link.rel === 'items')
     .map((link) => link.type);
-  return { formats, ...props } as OgcApiCollectionInfo;
+  const bulkDownloadLinks = links
+    .filter((link) => link.rel === 'enclosure')
+    .reduce((acc, link) => {
+      acc[link.type] = link.href;
+      return acc;
+    }, {});
+  return { formats, bulkDownloadLinks, ...props } as OgcApiCollectionInfo;
 }
 
 export function parseCollectionParameters(

--- a/src/ogc-api/model.ts
+++ b/src/ogc-api/model.ts
@@ -31,7 +31,8 @@ export interface OgcApiCollectionInfo {
   description: string;
   id: string;
   itemType: 'feature' | 'record';
-  formats: MimeType[];
+  formats: MimeType[]; // these formats are accessible through the /items API
+  bulkDownloadLinks: Record<string, MimeType>; // map between formats and bulk download links (no filtering, pagination etc.)
   crs: CrsCode[];
   storageCrs?: CrsCode;
   itemCount: number;


### PR DESCRIPTION
* More robust lookup of collection document: calling `getCollectionInfo` on the sample-data-2 fixtures was failing without this logic (no rel=self link is present on collections)
* Base documents of the endpoint (root doc, collections) are now queried lazily instead of eagerly at the endpoint creation; this will avoid unhandled promise rejection and offer clearer errors
* A new `bulkDownloadLinks` property was added to collections: these are links of type "enclosure" which do not offer pagination, filter etc. but only a bulk download; the property is a map between the mime type and the url