### PR TITLE
OGC API: use actual mimetype to generate an items url

### DIFF
--- a/fixtures/ogc-api/sample-data-2/collections/aires-covoiturage.json
+++ b/fixtures/ogc-api/sample-data-2/collections/aires-covoiturage.json
@@ -3,6 +3,12 @@
   "title": "aires-covoiturage",
   "links": [
     {
+      "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=html",
+      "rel": "items",
+      "type": "text/html",
+      "title": "aires-covoiturage"
+    },
+    {
       "href": "https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=geojson",
       "rel": "items",
       "type": "application/geo+json",

--- a/fixtures/ogc-api/sample-data/collections/airports.json
+++ b/fixtures/ogc-api/sample-data/collections/airports.json
@@ -57,6 +57,12 @@
     },
     {
       "rel": "items",
+      "type": "text/html",
+      "title": "Access the features in the collection 'Airports' as HTML",
+      "href": "https://my.server.org/sample-data/collections/airports/items?f=html"
+    },
+    {
+      "rel": "items",
       "type": "application/vnd.ogc.fg+json",
       "title": "Access the features in the collection 'Airports' as JSON-FG",
       "href": "https://my.server.org/sample-data/collections/airports/items?f=jsonfg"
@@ -78,12 +84,6 @@
       "type": "application/vnd.ogc.fg+json;compatibility=geojson",
       "title": "Access the features in the collection 'Airports' as JSON-FG (GeoJSON Compatibility Mode)",
       "href": "https://my.server.org/sample-data/collections/airports/items?f=jsonfgc"
-    },
-    {
-      "rel": "items",
-      "type": "text/html",
-      "title": "Access the features in the collection 'Airports' as HTML",
-      "href": "https://my.server.org/sample-data/collections/airports/items?f=html"
     }
   ],
   "id": "airports",

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -218,11 +218,11 @@ describe('OgcApiEndpoint', () => {
             'A centre point for all major airports including a name.',
           id: 'airports',
           itemFormats: [
+            'text/html',
             'application/vnd.ogc.fg+json',
             'application/geo+json',
             'application/flatgeobuf',
             'application/vnd.ogc.fg+json;compatibility=geojson',
-            'text/html',
           ],
           bulkDownloadLinks: {},
           extent: {
@@ -1557,6 +1557,15 @@ describe('OgcApiEndpoint', () => {
         await expect(
           endpoint.getCollectionItemsUrl('airports')
         ).resolves.toEqual(
+          'https://my.server.org/sample-data/collections/airports/items?f=html'
+        );
+      });
+      it('selects the URL using JSON-FG if asJson is specified', async () => {
+        await expect(
+          endpoint.getCollectionItemsUrl('airports', {
+            asJson: true,
+          })
+        ).resolves.toEqual(
           'https://my.server.org/sample-data/collections/airports/items?f=jsonfg'
         );
       });
@@ -1761,7 +1770,7 @@ The document at http://local/nonexisting?f=json could not be fetched.`
             endpoint.getCollectionInfo('aires-covoiturage')
           ).resolves.toStrictEqual({
             crs: ['http://www.opengis.net/def/crs/OGC/1.3/CRS84', 'EPSG:4326'],
-            itemFormats: ['application/geo+json'],
+            itemFormats: ['text/html', 'application/geo+json'],
             bulkDownloadLinks: {
               'application/geo+json':
                 'https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=geojson&limit=-1',
@@ -1780,6 +1789,18 @@ The document at http://local/nonexisting?f=json could not be fetched.`
             sortables: [],
             title: 'aires-covoiturage',
           });
+        });
+      });
+
+      describe('#getCollectionItemsUrl', () => {
+        it('selects the URL using GeoJson if asJson is specified', async () => {
+          await expect(
+            endpoint.getCollectionItemsUrl('aires-covoiturage', {
+              asJson: true,
+            })
+          ).resolves.toEqual(
+            'https://my.server.org/sample-data-2/collections/aires-covoiturage/items?f=geojson'
+          );
         });
       });
     });

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -1,4 +1,4 @@
-import { OgcApiDocument } from './model.js';
+import { OgcApiDocument, OgcApiDocumentLink } from './model.js';
 import { EndpointError } from '../shared/errors.js';
 import { getFetchOptions } from '../shared/http-utils.js';
 
@@ -75,21 +75,27 @@ export function fetchCollectionRoot(
   });
 }
 
+export function getLinks(
+  doc: OgcApiDocument,
+  relType: string | string[]
+): OgcApiDocumentLink[] {
+  return (
+    doc.links?.filter((link) =>
+      Array.isArray(relType)
+        ? relType.indexOf(link.rel) > -1
+        : link.rel === relType
+    ) || []
+  );
+}
+
 export function getLinkUrl(
   doc: OgcApiDocument,
   relType: string | string[],
   baseUrl?: string
-): string {
-  const links = doc.links?.filter((link) =>
-    Array.isArray(relType)
-      ? relType.indexOf(link.rel) > -1
-      : link.rel === relType
-  );
-  if (!links?.length) return null;
-  return new URL(
-    links[0].href,
-    baseUrl || window.location.toString()
-  ).toString();
+): string | null {
+  const link = getLinks(doc, relType)[0];
+  if (!link) return null;
+  return new URL(link.href, baseUrl || window.location.toString()).toString();
 }
 
 export function fetchLink(

--- a/src/ogc-api/model.ts
+++ b/src/ogc-api/model.ts
@@ -56,7 +56,7 @@ export interface OgcApiCollectionInfo {
   sortables: CollectionParameter[];
 }
 
-export interface OgcApiDocumentLinks {
+export interface OgcApiDocumentLink {
   rel: string;
   type: string;
   title: string;
@@ -92,7 +92,7 @@ interface OgcApiTime {
 }
 export interface OgcApiRecordContact {
   name: string;
-  links: OgcApiDocumentLinks[];
+  links: OgcApiDocumentLink[];
   contactInstructions: string;
   roles: string[];
 }
@@ -118,7 +118,7 @@ export type OgcApiRecord = {
   time: OgcApiTime;
   geometry: Geometry;
   properties: OgcApiRecordProperties;
-  links: OgcApiDocumentLinks[];
+  links: OgcApiDocumentLink[];
   conformsTo?: string[];
 };
 

--- a/src/ogc-api/model.ts
+++ b/src/ogc-api/model.ts
@@ -26,18 +26,39 @@ export interface CollectionParameter {
   type: CollectionParameterType;
 }
 
+/**
+ * Contains all necessary information about a collection of items
+ * @property title
+ * @property description
+ * @property id
+ * @property itemType
+ * @property itemFormats These mime types are available through the `/items` endpoint;
+ *  use the `getCollectionItemsUrl` function to generate a URL using one of those formats
+ * @property bulkDownloadLinks Map between formats and bulk download links (no filtering, pagination etc.)
+ * @property crs
+ * @property storageCrs
+ * @property itemCount
+ * @property keywords
+ * @property language Language is Iso 2-letter code (e.g. 'en')
+ * @property updated
+ * @property extent
+ * @property publisher
+ * @property license
+ * @property queryables
+ * @property sortables
+ */
 export interface OgcApiCollectionInfo {
   title: string;
   description: string;
   id: string;
   itemType: 'feature' | 'record';
-  itemFormats: MimeType[]; // these formats are accessible through the /items API
-  bulkDownloadLinks: Record<string, MimeType>; // map between formats and bulk download links (no filtering, pagination etc.)
+  itemFormats: MimeType[];
+  bulkDownloadLinks: Record<string, MimeType>;
   crs: CrsCode[];
   storageCrs?: CrsCode;
   itemCount: number;
   keywords?: string[];
-  language?: string; // ISO2
+  language?: string;
   updated?: Date;
   extent?: BoundingBox;
   publisher?: {

--- a/src/shared/mime-type.spec.ts
+++ b/src/shared/mime-type.spec.ts
@@ -1,0 +1,22 @@
+import { isMimeTypeJson, isMimeTypeJsonFg } from './mime-type.js';
+
+describe('mime type utils', () => {
+  it('isMimeTypeGeoJson', () => {
+    expect(isMimeTypeJson('application/geo+json')).toBe(true);
+    expect(isMimeTypeJson('application/vnd.geo+json')).toBe(true);
+    expect(isMimeTypeJson('geo+json')).toBe(true);
+    expect(isMimeTypeJson('geojson')).toBe(true);
+    expect(isMimeTypeJson('application/json')).toBe(true);
+    expect(isMimeTypeJson('json')).toBe(true);
+  });
+  it('isMimeTypeJsonFg', () => {
+    expect(isMimeTypeJsonFg('application/vnd.ogc.fg+json')).toBe(true);
+    expect(isMimeTypeJsonFg('fg+json')).toBe(true);
+    expect(isMimeTypeJsonFg('jsonfg')).toBe(true);
+    expect(isMimeTypeJsonFg('json-fg')).toBe(true);
+    expect(isMimeTypeJsonFg('geo+json')).toBe(false);
+    expect(isMimeTypeJsonFg('geojson')).toBe(false);
+    expect(isMimeTypeJsonFg('application/json')).toBe(false);
+    expect(isMimeTypeJsonFg('json')).toBe(false);
+  });
+});

--- a/src/shared/mime-type.ts
+++ b/src/shared/mime-type.ts
@@ -1,0 +1,7 @@
+export function isMimeTypeJson(mimeType: string): boolean {
+  return mimeType.toLowerCase().indexOf('json') > -1;
+}
+
+export function isMimeTypeJsonFg(mimeType: string): boolean {
+  return /json.?fg|fg.?json/.test(mimeType);
+}

--- a/src/wfs/endpoint.ts
+++ b/src/wfs/endpoint.ts
@@ -22,6 +22,7 @@ import {
   WfsFeatureTypeSummary,
   WfsVersion,
 } from './model.js';
+import { isMimeTypeJson } from '../shared/mime-type.js';
 
 /**
  * Represents a WFS endpoint advertising several feature types
@@ -221,9 +222,7 @@ export default class WfsEndpoint {
         `The following feature type was not found in the service: ${featureType}`
       );
     }
-    const candidates = featureTypeInfo.outputFormats.filter(
-      (f) => f.toLowerCase().indexOf('json') > -1
-    );
+    const candidates = featureTypeInfo.outputFormats.filter(isMimeTypeJson);
     if (!candidates.length) return null;
     return candidates[0];
   }


### PR DESCRIPTION
This PR improves the way getCollectionItmsUrl by choosing one of the available items url according to the desired mime-type, instead of generating it dynamically.

Also adds an `asJson` option to simply get the first items url that matches JSON-FG or GeoJSON.