### PR TITLE
Minor improvements to the application docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A provided application containing the documentation and demo is located in the `
 To start it locally, clone the repository and run the following commands:
 
 ```bash
+$ npm install
 $ cd app
 $ npm install
 $ npm start

--- a/app/src/Docs.vue
+++ b/app/src/Docs.vue
@@ -181,7 +181,7 @@ async function getFeatureUrl() {
 import { OgcApiEndpoint } from '@camptocamp/ogc-client';
 
 async function getFirstTenRecords() {
-  const endpoint = await new OgcApiEndpoint('https://my.server.org/main')
+  const endpoint = new OgcApiEndpoint('https://my.server.org/main');
   const firstCollection = (await endpoint.recordCollections)[0];
   return endpoint.getCollectionItems(firstCollection, 10, 0);
 }</pre


### PR DESCRIPTION
- to run the example app you need to run `npm install` in the main package as well
- remove unnecessary `await` in the example code