### PR TITLE
Auto-publish @dev version on NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish NPM package @dev version
+
+# This workflow runs whenever a commit is pushed on main
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-npm-package:
+    name: Publish NPM package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node & NPM
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+        # New version will be <npm version>.<commit hash>, e.g. 1.1.1-dev.0a4c598
+      - name: Adjust package version according to branch & commit
+        run: npm version $(node --print 'require("./package.json").version').$(git rev-parse --short HEAD) --no-git-tag-version --allow-same-version
+
+      - name: Publish NPM package with @dev tag
+        run: npm publish --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ogc-client
+# ogc-client [![Latest version on NPM](https://img.shields.io/npm/v/%40camptocamp%2Fogc-client)](https://www.npmjs.com/package/@camptocamp/ogc-client) [![Latest @dev version on NPM](https://img.shields.io/npm/v/%40camptocamp%2Fogc-client/dev)](https://www.npmjs.com/package/@camptocamp/ogc-client?activeTab=versions)
 
 > A Typescript library for interacting with [OGC-compliant services](https://www.ogc.org/docs/is)
 
@@ -47,6 +47,14 @@ enableFallbackWithoutWorker();
 ```
 
 All processing will be done on the main thread after this call, including HTTP requests.
+
+### Use the latest development version
+
+[The `@camptocamp/ogc-client` NPM package](https://www.npmjs.com/package/@camptocamp/ogc-client) is updated on every commit on the `main` branch under the `@dev` tag. To use it:
+
+```bash
+$ npm install --save @camptocamp/ogc-client@dev
+```
 
 ### Application
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@camptocamp/ogc-client",
-  "version": "1.1.0",
+  "version": "1.1.1-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@camptocamp/ogc-client",
-      "version": "1.1.0",
+      "version": "1.1.1-dev",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@camptocamp/ogc-client",
-  "version": "1.1.0",
+  "version": "1.1.1-dev",
   "description": "A pure JS library for interacting with geospatial services.",
   "main": "./dist/dist-node.js",
   "browser": "./dist/index.js",


### PR DESCRIPTION
The workflow will only run on the `main` branch.

The version published will be `<npm version>.<git commit>`, e.g.: `1.1.1-dev.0a4c598`

This PR also bumps the version to 1.1.1-dev