### PR TITLE
Support for OGC API Styles

### DIFF
--- a/fixtures/ogc-api/sample-data/collections/airports/styles/Tritanopia/metadata.json
+++ b/fixtures/ogc-api/sample-data/collections/airports/styles/Tritanopia/metadata.json
@@ -1,0 +1,39 @@
+{
+  "title" : "Tritanopia",
+  "links" : [ {
+    "rel" : "self",
+    "type" : "application/json",
+    "title" : "This document",
+    "href" : "https://my.server.org/sample-data/collections/airports/styles/Tritanopia/metadata?f=json"
+  }, {
+    "rel" : "alternate",
+    "type" : "text/html",
+    "title" : "This document as HTML",
+    "href" : "https://my.server.org/sample-data/collections/airports/styles/Tritanopia/metadata?f=html"
+  } ],
+  "id" : "Tritanopia",
+  "scope" : "style",
+  "stylesheets" : [ {
+    "title" : "QGIS",
+    "version" : "3.16",
+    "specification" : "https://docs.qgis.org/3.16/en/docs/user_manual/appendices/qgis_file_formats.html#qml-the-qgis-style-file-format",
+    "native" : true,
+    "link" : {
+      "rel" : "stylesheet",
+      "type" : "application/vnd.qgis.qml",
+      "title" : "Style in format 'QGIS'",
+      "href" : "https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=qml"
+    }
+  }, {
+    "title" : "SLD 1.0",
+    "version" : "1.0",
+    "specification" : "https://www.ogc.org/standards/sld",
+    "native" : true,
+    "link" : {
+      "rel" : "stylesheet",
+      "type" : "application/vnd.ogc.sld+xml;version=1.0",
+      "title" : "Style in format 'SLD 1.0'",
+      "href" : "https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=sld10"
+    }
+  } ]
+}

--- a/fixtures/ogc-api/sample-data/collections/airports/styles/Tritanopia/metadata.json
+++ b/fixtures/ogc-api/sample-data/collections/airports/styles/Tritanopia/metadata.json
@@ -1,39 +1,45 @@
 {
-  "title" : "Tritanopia",
-  "links" : [ {
-    "rel" : "self",
-    "type" : "application/json",
-    "title" : "This document",
-    "href" : "https://my.server.org/sample-data/collections/airports/styles/Tritanopia/metadata?f=json"
-  }, {
-    "rel" : "alternate",
-    "type" : "text/html",
-    "title" : "This document as HTML",
-    "href" : "https://my.server.org/sample-data/collections/airports/styles/Tritanopia/metadata?f=html"
-  } ],
-  "id" : "Tritanopia",
-  "scope" : "style",
-  "stylesheets" : [ {
-    "title" : "QGIS",
-    "version" : "3.16",
-    "specification" : "https://docs.qgis.org/3.16/en/docs/user_manual/appendices/qgis_file_formats.html#qml-the-qgis-style-file-format",
-    "native" : true,
-    "link" : {
-      "rel" : "stylesheet",
-      "type" : "application/vnd.qgis.qml",
-      "title" : "Style in format 'QGIS'",
-      "href" : "https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=qml"
+  "title": "Tritanopia",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/sample-data/collections/airports/styles/Tritanopia/metadata?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/sample-data/collections/airports/styles/Tritanopia/metadata?f=html"
     }
-  }, {
-    "title" : "SLD 1.0",
-    "version" : "1.0",
-    "specification" : "https://www.ogc.org/standards/sld",
-    "native" : true,
-    "link" : {
-      "rel" : "stylesheet",
-      "type" : "application/vnd.ogc.sld+xml;version=1.0",
-      "title" : "Style in format 'SLD 1.0'",
-      "href" : "https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=sld10"
+  ],
+  "id": "Tritanopia",
+  "scope": "style",
+  "stylesheets": [
+    {
+      "title": "QGIS",
+      "version": "3.16",
+      "specification": "https://docs.qgis.org/3.16/en/docs/user_manual/appendices/qgis_file_formats.html#qml-the-qgis-style-file-format",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.qgis.qml",
+        "title": "Style in format 'QGIS'",
+        "href": "https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=qml"
+      }
+    },
+    {
+      "title": "SLD 1.0",
+      "version": "1.0",
+      "specification": "https://www.ogc.org/standards/sld",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.ogc.sld+xml;version=1.0",
+        "title": "Style in format 'SLD 1.0'",
+        "href": "https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=sld10"
+      }
     }
-  } ]
+  ]
 }

--- a/fixtures/ogc-api/sample-data/styles/Deuteranopia/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/Deuteranopia/metadata.json
@@ -1,0 +1,33 @@
+{
+  "title": "Deuteranopia",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "http://local/zoomstack/styles/Deuteranopia/metadata?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "http://local/zoomstack/styles/Deuteranopia/metadata?f=html"
+    }
+  ],
+  "id": "Deuteranopia",
+  "scope": "style",
+  "stylesheets": [
+    {
+      "title": "ArcGIS",
+      "version": "n/a",
+      "specification": "https://www.esri.com/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.esri.lyr",
+        "title": "Style in format 'ArcGIS'",
+        "href": "http://local/zoomstack/styles/Deuteranopia?f=lyr"
+      }
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/styles/Light/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/Light/metadata.json
@@ -1,0 +1,378 @@
+{
+  "title" : "OS Open Zoomstack - Light",
+  "links" : [ {
+    "rel" : "self",
+    "type" : "application/json",
+    "title" : "This document",
+    "href" : "https://local/zoomstack/styles/Light/metadata?f=json"
+  }, {
+    "rel" : "alternate",
+    "type" : "text/html",
+    "title" : "This document as HTML",
+    "href" : "https://local/zoomstack/styles/Light/metadata?f=html"
+  } ],
+  "id" : "Light",
+  "scope" : "style",
+  "stylesheets" : [ {
+    "title" : "ArcGIS",
+    "version" : "n/a",
+    "specification" : "https://www.esri.com/",
+    "native" : true,
+    "link" : {
+      "rel" : "stylesheet",
+      "type" : "application/vnd.esri.lyr",
+      "title" : "Style in format 'ArcGIS'",
+      "href" : "https://local/zoomstack/styles/Light?f=lyr"
+    }
+  }, {
+    "title" : "Mapbox",
+    "version" : "8",
+    "specification" : "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
+    "native" : true,
+    "link" : {
+      "rel" : "stylesheet",
+      "type" : "application/vnd.mapbox.style+json",
+      "title" : "Style in format 'Mapbox'",
+      "href" : "https://local/zoomstack/styles/Light?f=mbs"
+    }
+  } ],
+  "layers" : [ {
+    "id" : "background"
+  }, {
+    "id" : "sea",
+    "type" : "geometry"
+  }, {
+    "id" : "national-parks",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/national_parks/items"
+    }
+  }, {
+    "id" : "urban-areas",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/urban_areas/items"
+    }
+  }, {
+    "id" : "sites",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/sites/items"
+    }
+  }, {
+    "id" : "greenspace",
+    "type" : "geometry"
+  }, {
+    "id" : "greenspace outlines",
+    "type" : "geometry"
+  }, {
+    "id" : "woodland",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/woodland/items"
+    }
+  }, {
+    "id" : "surfacewater",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/surfacewater/items"
+    }
+  }, {
+    "id" : "foreshore",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/foreshore/items"
+    }
+  }, {
+    "id" : "waterlines",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/waterlines/items"
+    }
+  }, {
+    "id" : "buildings",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Restricted Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Local Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Guided Busway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Guided Busway Centreline",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Motorway",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Minor Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 B Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 A Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Primary Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Local Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Minor Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 B Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 A Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Primary Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Motorway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Restricted Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Local Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Guided Busway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Guided Busway Centreline",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Motorway",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Minor Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 B Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 A Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Primary Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Local Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Minor Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 B Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 A Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Primary Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Motorway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Restricted Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Local Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Guided Busway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Guided Busway Centreline",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Motorway",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Minor Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 B Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 A Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Primary Road",
+    "type" : "geometry"
+  }, {
+    "id" : "road Tunnels",
+    "type" : "geometry"
+  }, {
+    "id" : "rail",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/rail/items"
+    }
+  }, {
+    "id" : "rail tunnel",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/rail/items"
+    }
+  }, {
+    "id" : "boundaries",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/boundaries/items"
+    }
+  }, {
+    "id" : "etl",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/etl/items"
+    }
+  }, {
+    "id" : "road numbers",
+    "type" : "geometry"
+  }, {
+    "id" : "road names",
+    "type" : "geometry"
+  }, {
+    "id" : "primary road numbers",
+    "type" : "geometry"
+  }, {
+    "id" : "motorway numbers",
+    "type" : "geometry"
+  }, {
+    "id" : "motorway junction numbers",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "greenspace names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "sites names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "landform names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "landcover names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "water names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "woodland names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "small settlement names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "suburban area names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "railwaystations",
+    "type" : "geometry"
+  }, {
+    "id" : "airports",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/airports/items"
+    }
+  }, {
+    "id" : "village and hamlet names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "town names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "city names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "national park names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "capital city names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "country names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  } ]
+}

--- a/fixtures/ogc-api/sample-data/styles/Light/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/Light/metadata.json
@@ -1,378 +1,462 @@
 {
-  "title" : "OS Open Zoomstack - Light",
-  "links" : [ {
-    "rel" : "self",
-    "type" : "application/json",
-    "title" : "This document",
-    "href" : "https://local/zoomstack/styles/Light/metadata?f=json"
-  }, {
-    "rel" : "alternate",
-    "type" : "text/html",
-    "title" : "This document as HTML",
-    "href" : "https://local/zoomstack/styles/Light/metadata?f=html"
-  } ],
-  "id" : "Light",
-  "scope" : "style",
-  "stylesheets" : [ {
-    "title" : "ArcGIS",
-    "version" : "n/a",
-    "specification" : "https://www.esri.com/",
-    "native" : true,
-    "link" : {
-      "rel" : "stylesheet",
-      "type" : "application/vnd.esri.lyr",
-      "title" : "Style in format 'ArcGIS'",
-      "href" : "https://local/zoomstack/styles/Light?f=lyr"
+  "title": "OS Open Zoomstack - Light",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://local/zoomstack/styles/Light/metadata?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://local/zoomstack/styles/Light/metadata?f=html"
     }
-  }, {
-    "title" : "Mapbox",
-    "version" : "8",
-    "specification" : "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
-    "native" : true,
-    "link" : {
-      "rel" : "stylesheet",
-      "type" : "application/vnd.mapbox.style+json",
-      "title" : "Style in format 'Mapbox'",
-      "href" : "https://local/zoomstack/styles/Light?f=mbs"
+  ],
+  "id": "Light",
+  "scope": "style",
+  "stylesheets": [
+    {
+      "title": "ArcGIS",
+      "version": "n/a",
+      "specification": "https://www.esri.com/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.esri.lyr",
+        "title": "Style in format 'ArcGIS'",
+        "href": "https://local/zoomstack/styles/Light?f=lyr"
+      }
+    },
+    {
+      "title": "Mapbox",
+      "version": "8",
+      "specification": "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.mapbox.style+json",
+        "title": "Style in format 'Mapbox'",
+        "href": "https://local/zoomstack/styles/Light?f=mbs"
+      }
     }
-  } ],
-  "layers" : [ {
-    "id" : "background"
-  }, {
-    "id" : "sea",
-    "type" : "geometry"
-  }, {
-    "id" : "national-parks",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/national_parks/items"
+  ],
+  "layers": [
+    {
+      "id": "background"
+    },
+    {
+      "id": "sea",
+      "type": "geometry"
+    },
+    {
+      "id": "national-parks",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/national_parks/items"
+      }
+    },
+    {
+      "id": "urban-areas",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/urban_areas/items"
+      }
+    },
+    {
+      "id": "sites",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/sites/items"
+      }
+    },
+    {
+      "id": "greenspace",
+      "type": "geometry"
+    },
+    {
+      "id": "greenspace outlines",
+      "type": "geometry"
+    },
+    {
+      "id": "woodland",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/woodland/items"
+      }
+    },
+    {
+      "id": "surfacewater",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/surfacewater/items"
+      }
+    },
+    {
+      "id": "foreshore",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/foreshore/items"
+      }
+    },
+    {
+      "id": "waterlines",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/waterlines/items"
+      }
+    },
+    {
+      "id": "buildings",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "road Tunnels",
+      "type": "geometry"
+    },
+    {
+      "id": "rail",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/rail/items"
+      }
+    },
+    {
+      "id": "rail tunnel",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/rail/items"
+      }
+    },
+    {
+      "id": "boundaries",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/boundaries/items"
+      }
+    },
+    {
+      "id": "etl",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/etl/items"
+      }
+    },
+    {
+      "id": "road numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "road names",
+      "type": "geometry"
+    },
+    {
+      "id": "primary road numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "motorway numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "motorway junction numbers",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "greenspace names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "sites names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "landform names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "landcover names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "water names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "woodland names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "small settlement names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "suburban area names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "railwaystations",
+      "type": "geometry"
+    },
+    {
+      "id": "airports",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/airports/items"
+      }
+    },
+    {
+      "id": "village and hamlet names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "town names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "city names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "national park names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "capital city names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "country names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
     }
-  }, {
-    "id" : "urban-areas",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/urban_areas/items"
-    }
-  }, {
-    "id" : "sites",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/sites/items"
-    }
-  }, {
-    "id" : "greenspace",
-    "type" : "geometry"
-  }, {
-    "id" : "greenspace outlines",
-    "type" : "geometry"
-  }, {
-    "id" : "woodland",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/woodland/items"
-    }
-  }, {
-    "id" : "surfacewater",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/surfacewater/items"
-    }
-  }, {
-    "id" : "foreshore",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/foreshore/items"
-    }
-  }, {
-    "id" : "waterlines",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/waterlines/items"
-    }
-  }, {
-    "id" : "buildings",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Restricted Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Local Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Guided Busway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Guided Busway Centreline",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Motorway",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Minor Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 B Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 A Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Primary Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Local Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Minor Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 B Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 A Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Primary Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Motorway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Restricted Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Local Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Guided Busway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Guided Busway Centreline",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Motorway",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Minor Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 B Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 A Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Primary Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Local Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Minor Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 B Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 A Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Primary Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Motorway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Restricted Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Local Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Guided Busway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Guided Busway Centreline",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Motorway",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Minor Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 B Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 A Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Primary Road",
-    "type" : "geometry"
-  }, {
-    "id" : "road Tunnels",
-    "type" : "geometry"
-  }, {
-    "id" : "rail",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/rail/items"
-    }
-  }, {
-    "id" : "rail tunnel",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/rail/items"
-    }
-  }, {
-    "id" : "boundaries",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/boundaries/items"
-    }
-  }, {
-    "id" : "etl",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/etl/items"
-    }
-  }, {
-    "id" : "road numbers",
-    "type" : "geometry"
-  }, {
-    "id" : "road names",
-    "type" : "geometry"
-  }, {
-    "id" : "primary road numbers",
-    "type" : "geometry"
-  }, {
-    "id" : "motorway numbers",
-    "type" : "geometry"
-  }, {
-    "id" : "motorway junction numbers",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "greenspace names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "sites names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "landform names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "landcover names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "water names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "woodland names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "small settlement names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "suburban area names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "railwaystations",
-    "type" : "geometry"
-  }, {
-    "id" : "airports",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/airports/items"
-    }
-  }, {
-    "id" : "village and hamlet names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "town names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "city names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "national park names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "capital city names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "country names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  } ]
+  ]
 }

--- a/fixtures/ogc-api/sample-data/styles/Night/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/Night/metadata.json
@@ -1,0 +1,378 @@
+{
+  "title" : "OS Open Zoomstack - Night",
+  "links" : [ {
+    "rel" : "self",
+    "type" : "application/json",
+    "title" : "This document",
+    "href" : "https://local/zoomstack/styles/Night/metadata?f=json"
+  }, {
+    "rel" : "alternate",
+    "type" : "text/html",
+    "title" : "This document as HTML",
+    "href" : "https://local/zoomstack/styles/Night/metadata?f=html"
+  } ],
+  "id" : "Night",
+  "scope" : "style",
+  "stylesheets" : [ {
+    "title" : "ArcGIS",
+    "version" : "n/a",
+    "specification" : "https://www.esri.com/",
+    "native" : true,
+    "link" : {
+      "rel" : "stylesheet",
+      "type" : "application/vnd.esri.lyr",
+      "title" : "Style in format 'ArcGIS'",
+      "href" : "https://local/zoomstack/styles/Night?f=lyr"
+    }
+  }, {
+    "title" : "Mapbox",
+    "version" : "8",
+    "specification" : "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
+    "native" : true,
+    "link" : {
+      "rel" : "stylesheet",
+      "type" : "application/vnd.mapbox.style+json",
+      "title" : "Style in format 'Mapbox'",
+      "href" : "https://local/zoomstack/styles/Night?f=mbs"
+    }
+  } ],
+  "layers" : [ {
+    "id" : "background"
+  }, {
+    "id" : "sea",
+    "type" : "geometry"
+  }, {
+    "id" : "national-parks",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/national_parks/items"
+    }
+  }, {
+    "id" : "urban-areas",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/urban_areas/items"
+    }
+  }, {
+    "id" : "sites",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/sites/items"
+    }
+  }, {
+    "id" : "greenspace",
+    "type" : "geometry"
+  }, {
+    "id" : "greenspace outlines",
+    "type" : "geometry"
+  }, {
+    "id" : "woodland",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/woodland/items"
+    }
+  }, {
+    "id" : "surfacewater",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/surfacewater/items"
+    }
+  }, {
+    "id" : "foreshore",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/foreshore/items"
+    }
+  }, {
+    "id" : "waterlines",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/waterlines/items"
+    }
+  }, {
+    "id" : "buildings",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Restricted Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Local Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Guided Busway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Guided Busway Centreline",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Motorway",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Minor Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 B Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 A Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Primary Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Local Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Minor Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 B Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 A Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Primary Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Motorway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Restricted Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Local Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Guided Busway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Guided Busway Centreline",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Motorway",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Minor Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 B Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 A Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Primary Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Local Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Minor Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 B Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 A Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Primary Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Motorway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Restricted Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Local Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Guided Busway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Guided Busway Centreline",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Motorway",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Minor Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 B Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 A Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Primary Road",
+    "type" : "geometry"
+  }, {
+    "id" : "road Tunnels",
+    "type" : "geometry"
+  }, {
+    "id" : "rail",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/rail/items"
+    }
+  }, {
+    "id" : "rail tunnel",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/rail/items"
+    }
+  }, {
+    "id" : "boundaries",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/boundaries/items"
+    }
+  }, {
+    "id" : "etl",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/etl/items"
+    }
+  }, {
+    "id" : "road numbers",
+    "type" : "geometry"
+  }, {
+    "id" : "road names",
+    "type" : "geometry"
+  }, {
+    "id" : "primary road numbers",
+    "type" : "geometry"
+  }, {
+    "id" : "motorway numbers",
+    "type" : "geometry"
+  }, {
+    "id" : "motorway junction numbers",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "greenspace names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "sites names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "landform names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "landcover names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "water names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "woodland names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "small settlement names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "suburban area names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "railwaystations",
+    "type" : "geometry"
+  }, {
+    "id" : "airports",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/airports/items"
+    }
+  }, {
+    "id" : "village and hamlet names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "town names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "city names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "national park names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "capital city names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "country names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  } ]
+}

--- a/fixtures/ogc-api/sample-data/styles/Night/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/Night/metadata.json
@@ -1,378 +1,462 @@
 {
-  "title" : "OS Open Zoomstack - Night",
-  "links" : [ {
-    "rel" : "self",
-    "type" : "application/json",
-    "title" : "This document",
-    "href" : "https://local/zoomstack/styles/Night/metadata?f=json"
-  }, {
-    "rel" : "alternate",
-    "type" : "text/html",
-    "title" : "This document as HTML",
-    "href" : "https://local/zoomstack/styles/Night/metadata?f=html"
-  } ],
-  "id" : "Night",
-  "scope" : "style",
-  "stylesheets" : [ {
-    "title" : "ArcGIS",
-    "version" : "n/a",
-    "specification" : "https://www.esri.com/",
-    "native" : true,
-    "link" : {
-      "rel" : "stylesheet",
-      "type" : "application/vnd.esri.lyr",
-      "title" : "Style in format 'ArcGIS'",
-      "href" : "https://local/zoomstack/styles/Night?f=lyr"
+  "title": "OS Open Zoomstack - Night",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://local/zoomstack/styles/Night/metadata?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://local/zoomstack/styles/Night/metadata?f=html"
     }
-  }, {
-    "title" : "Mapbox",
-    "version" : "8",
-    "specification" : "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
-    "native" : true,
-    "link" : {
-      "rel" : "stylesheet",
-      "type" : "application/vnd.mapbox.style+json",
-      "title" : "Style in format 'Mapbox'",
-      "href" : "https://local/zoomstack/styles/Night?f=mbs"
+  ],
+  "id": "Night",
+  "scope": "style",
+  "stylesheets": [
+    {
+      "title": "ArcGIS",
+      "version": "n/a",
+      "specification": "https://www.esri.com/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.esri.lyr",
+        "title": "Style in format 'ArcGIS'",
+        "href": "https://local/zoomstack/styles/Night?f=lyr"
+      }
+    },
+    {
+      "title": "Mapbox",
+      "version": "8",
+      "specification": "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.mapbox.style+json",
+        "title": "Style in format 'Mapbox'",
+        "href": "https://local/zoomstack/styles/Night?f=mbs"
+      }
     }
-  } ],
-  "layers" : [ {
-    "id" : "background"
-  }, {
-    "id" : "sea",
-    "type" : "geometry"
-  }, {
-    "id" : "national-parks",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/national_parks/items"
+  ],
+  "layers": [
+    {
+      "id": "background"
+    },
+    {
+      "id": "sea",
+      "type": "geometry"
+    },
+    {
+      "id": "national-parks",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/national_parks/items"
+      }
+    },
+    {
+      "id": "urban-areas",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/urban_areas/items"
+      }
+    },
+    {
+      "id": "sites",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/sites/items"
+      }
+    },
+    {
+      "id": "greenspace",
+      "type": "geometry"
+    },
+    {
+      "id": "greenspace outlines",
+      "type": "geometry"
+    },
+    {
+      "id": "woodland",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/woodland/items"
+      }
+    },
+    {
+      "id": "surfacewater",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/surfacewater/items"
+      }
+    },
+    {
+      "id": "foreshore",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/foreshore/items"
+      }
+    },
+    {
+      "id": "waterlines",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/waterlines/items"
+      }
+    },
+    {
+      "id": "buildings",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "road Tunnels",
+      "type": "geometry"
+    },
+    {
+      "id": "rail",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/rail/items"
+      }
+    },
+    {
+      "id": "rail tunnel",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/rail/items"
+      }
+    },
+    {
+      "id": "boundaries",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/boundaries/items"
+      }
+    },
+    {
+      "id": "etl",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/etl/items"
+      }
+    },
+    {
+      "id": "road numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "road names",
+      "type": "geometry"
+    },
+    {
+      "id": "primary road numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "motorway numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "motorway junction numbers",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "greenspace names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "sites names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "landform names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "landcover names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "water names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "woodland names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "small settlement names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "suburban area names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "railwaystations",
+      "type": "geometry"
+    },
+    {
+      "id": "airports",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/airports/items"
+      }
+    },
+    {
+      "id": "village and hamlet names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "town names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "city names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "national park names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "capital city names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "country names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
     }
-  }, {
-    "id" : "urban-areas",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/urban_areas/items"
-    }
-  }, {
-    "id" : "sites",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/sites/items"
-    }
-  }, {
-    "id" : "greenspace",
-    "type" : "geometry"
-  }, {
-    "id" : "greenspace outlines",
-    "type" : "geometry"
-  }, {
-    "id" : "woodland",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/woodland/items"
-    }
-  }, {
-    "id" : "surfacewater",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/surfacewater/items"
-    }
-  }, {
-    "id" : "foreshore",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/foreshore/items"
-    }
-  }, {
-    "id" : "waterlines",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/waterlines/items"
-    }
-  }, {
-    "id" : "buildings",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Restricted Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Local Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Guided Busway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Guided Busway Centreline",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Motorway",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Minor Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 B Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 A Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Primary Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Local Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Minor Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 B Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 A Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Primary Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Motorway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Restricted Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Local Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Guided Busway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Guided Busway Centreline",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Motorway",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Minor Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 B Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 A Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Primary Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Local Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Minor Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 B Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 A Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Primary Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Motorway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Restricted Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Local Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Guided Busway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Guided Busway Centreline",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Motorway",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Minor Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 B Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 A Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Primary Road",
-    "type" : "geometry"
-  }, {
-    "id" : "road Tunnels",
-    "type" : "geometry"
-  }, {
-    "id" : "rail",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/rail/items"
-    }
-  }, {
-    "id" : "rail tunnel",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/rail/items"
-    }
-  }, {
-    "id" : "boundaries",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/boundaries/items"
-    }
-  }, {
-    "id" : "etl",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/etl/items"
-    }
-  }, {
-    "id" : "road numbers",
-    "type" : "geometry"
-  }, {
-    "id" : "road names",
-    "type" : "geometry"
-  }, {
-    "id" : "primary road numbers",
-    "type" : "geometry"
-  }, {
-    "id" : "motorway numbers",
-    "type" : "geometry"
-  }, {
-    "id" : "motorway junction numbers",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "greenspace names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "sites names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "landform names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "landcover names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "water names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "woodland names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "small settlement names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "suburban area names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "railwaystations",
-    "type" : "geometry"
-  }, {
-    "id" : "airports",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/airports/items"
-    }
-  }, {
-    "id" : "village and hamlet names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "town names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "city names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "national park names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "capital city names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "country names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  } ]
+  ]
 }

--- a/fixtures/ogc-api/sample-data/styles/Outdoor/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/Outdoor/metadata.json
@@ -1,405 +1,494 @@
 {
-  "title" : "OS Open Zoomstack - Outdoor",
-  "links" : [ {
-    "rel" : "self",
-    "type" : "application/json",
-    "title" : "This document",
-    "href" : "https://local/zoomstack/styles/Outdoor/metadata?f=json"
-  }, {
-    "rel" : "alternate",
-    "type" : "text/html",
-    "title" : "This document as HTML",
-    "href" : "https://local/zoomstack/styles/Outdoor/metadata?f=html"
-  } ],
-  "id" : "Outdoor",
-  "scope" : "style",
-  "stylesheets" : [ {
-    "title" : "ArcGIS",
-    "version" : "n/a",
-    "specification" : "https://www.esri.com/",
-    "native" : true,
-    "link" : {
-      "rel" : "stylesheet",
-      "type" : "application/vnd.esri.lyr",
-      "title" : "Style in format 'ArcGIS'",
-      "href" : "https://local/zoomstack/styles/Outdoor?f=lyr"
+  "title": "OS Open Zoomstack - Outdoor",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://local/zoomstack/styles/Outdoor/metadata?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://local/zoomstack/styles/Outdoor/metadata?f=html"
     }
-  }, {
-    "title" : "Mapbox",
-    "version" : "8",
-    "specification" : "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
-    "native" : true,
-    "link" : {
-      "rel" : "stylesheet",
-      "type" : "application/vnd.mapbox.style+json",
-      "title" : "Style in format 'Mapbox'",
-      "href" : "https://local/zoomstack/styles/Outdoor?f=mbs"
+  ],
+  "id": "Outdoor",
+  "scope": "style",
+  "stylesheets": [
+    {
+      "title": "ArcGIS",
+      "version": "n/a",
+      "specification": "https://www.esri.com/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.esri.lyr",
+        "title": "Style in format 'ArcGIS'",
+        "href": "https://local/zoomstack/styles/Outdoor?f=lyr"
+      }
+    },
+    {
+      "title": "Mapbox",
+      "version": "8",
+      "specification": "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.mapbox.style+json",
+        "title": "Style in format 'Mapbox'",
+        "href": "https://local/zoomstack/styles/Outdoor?f=mbs"
+      }
     }
-  } ],
-  "layers" : [ {
-    "id" : "background"
-  }, {
-    "id" : "sea shadow",
-    "type" : "geometry"
-  }, {
-    "id" : "sea",
-    "type" : "geometry"
-  }, {
-    "id" : "national-parks",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/national_parks/items"
+  ],
+  "layers": [
+    {
+      "id": "background"
+    },
+    {
+      "id": "sea shadow",
+      "type": "geometry"
+    },
+    {
+      "id": "sea",
+      "type": "geometry"
+    },
+    {
+      "id": "national-parks",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/national_parks/items"
+      }
+    },
+    {
+      "id": "urban-areas",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/urban_areas/items"
+      }
+    },
+    {
+      "id": "sites",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/sites/items"
+      }
+    },
+    {
+      "id": "greenspace",
+      "type": "geometry"
+    },
+    {
+      "id": "greenspace outlines",
+      "type": "geometry"
+    },
+    {
+      "id": "woodland",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/woodland/items"
+      }
+    },
+    {
+      "id": "contours",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/contours/items"
+      }
+    },
+    {
+      "id": "surfacewater shadow",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/surfacewater/items"
+      }
+    },
+    {
+      "id": "surfacewater",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/surfacewater/items"
+      }
+    },
+    {
+      "id": "foreshore",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/foreshore/items"
+      }
+    },
+    {
+      "id": "waterlines",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/waterlines/items"
+      }
+    },
+    {
+      "id": "buildings 2D",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "road Tunnels",
+      "type": "geometry"
+    },
+    {
+      "id": "rail",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/rail/items"
+      }
+    },
+    {
+      "id": "rail tunnel",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/rail/items"
+      }
+    },
+    {
+      "id": "buildings 3D",
+      "type": "geometry"
+    },
+    {
+      "id": "boundaries",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/boundaries/items"
+      }
+    },
+    {
+      "id": "etl",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/etl/items"
+      }
+    },
+    {
+      "id": "road numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "road names",
+      "type": "geometry"
+    },
+    {
+      "id": "primary road numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "motorway numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "contour labels",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/contours/items"
+      }
+    },
+    {
+      "id": "motorway junction numbers",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "greenspace names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "sites names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "landform names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "landcover names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "water names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "woodland names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "small settlement names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "suburban area names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "railwaystations",
+      "type": "geometry"
+    },
+    {
+      "id": "airports",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/airports/items"
+      }
+    },
+    {
+      "id": "village and hamlet names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "town names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "city names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "national park names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "capital city names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "country names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
+      }
     }
-  }, {
-    "id" : "urban-areas",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/urban_areas/items"
-    }
-  }, {
-    "id" : "sites",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/sites/items"
-    }
-  }, {
-    "id" : "greenspace",
-    "type" : "geometry"
-  }, {
-    "id" : "greenspace outlines",
-    "type" : "geometry"
-  }, {
-    "id" : "woodland",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/woodland/items"
-    }
-  }, {
-    "id" : "contours",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/contours/items"
-    }
-  }, {
-    "id" : "surfacewater shadow",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/surfacewater/items"
-    }
-  }, {
-    "id" : "surfacewater",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/surfacewater/items"
-    }
-  }, {
-    "id" : "foreshore",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/foreshore/items"
-    }
-  }, {
-    "id" : "waterlines",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/waterlines/items"
-    }
-  }, {
-    "id" : "buildings 2D",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Restricted Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Local Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Guided Busway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Guided Busway Centreline",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Motorway",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Minor Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 B Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 A Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 0 Primary Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Local Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Minor Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 B Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 A Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Primary Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Motorway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Restricted Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Local Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Guided Busway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Guided Busway Centreline",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Motorway",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Minor Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 B Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 A Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 1 Primary Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Local Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Minor Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 B Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 A Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Primary Road Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Motorway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Restricted Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Local Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Guided Busway Casing",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Guided Busway Centreline",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Motorway",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Minor Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 B Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 A Road",
-    "type" : "geometry"
-  }, {
-    "id" : "roads 2 Primary Road",
-    "type" : "geometry"
-  }, {
-    "id" : "road Tunnels",
-    "type" : "geometry"
-  }, {
-    "id" : "rail",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/rail/items"
-    }
-  }, {
-    "id" : "rail tunnel",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/rail/items"
-    }
-  }, {
-    "id" : "buildings 3D",
-    "type" : "geometry"
-  }, {
-    "id" : "boundaries",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/boundaries/items"
-    }
-  }, {
-    "id" : "etl",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/etl/items"
-    }
-  }, {
-    "id" : "road numbers",
-    "type" : "geometry"
-  }, {
-    "id" : "road names",
-    "type" : "geometry"
-  }, {
-    "id" : "primary road numbers",
-    "type" : "geometry"
-  }, {
-    "id" : "motorway numbers",
-    "type" : "geometry"
-  }, {
-    "id" : "contour labels",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/contours/items"
-    }
-  }, {
-    "id" : "motorway junction numbers",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "greenspace names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "sites names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "landform names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "landcover names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "water names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "woodland names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "small settlement names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "suburban area names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "railwaystations",
-    "type" : "geometry"
-  }, {
-    "id" : "airports",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/airports/items"
-    }
-  }, {
-    "id" : "village and hamlet names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "town names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "city names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "national park names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "capital city names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  }, {
-    "id" : "country names",
-    "type" : "geometry",
-    "sampleData" : {
-      "rel" : "start",
-      "href" : "https://local/zoomstack/collections/names/items"
-    }
-  } ]
+  ]
 }

--- a/fixtures/ogc-api/sample-data/styles/Outdoor/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/Outdoor/metadata.json
@@ -1,0 +1,405 @@
+{
+  "title" : "OS Open Zoomstack - Outdoor",
+  "links" : [ {
+    "rel" : "self",
+    "type" : "application/json",
+    "title" : "This document",
+    "href" : "https://local/zoomstack/styles/Outdoor/metadata?f=json"
+  }, {
+    "rel" : "alternate",
+    "type" : "text/html",
+    "title" : "This document as HTML",
+    "href" : "https://local/zoomstack/styles/Outdoor/metadata?f=html"
+  } ],
+  "id" : "Outdoor",
+  "scope" : "style",
+  "stylesheets" : [ {
+    "title" : "ArcGIS",
+    "version" : "n/a",
+    "specification" : "https://www.esri.com/",
+    "native" : true,
+    "link" : {
+      "rel" : "stylesheet",
+      "type" : "application/vnd.esri.lyr",
+      "title" : "Style in format 'ArcGIS'",
+      "href" : "https://local/zoomstack/styles/Outdoor?f=lyr"
+    }
+  }, {
+    "title" : "Mapbox",
+    "version" : "8",
+    "specification" : "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
+    "native" : true,
+    "link" : {
+      "rel" : "stylesheet",
+      "type" : "application/vnd.mapbox.style+json",
+      "title" : "Style in format 'Mapbox'",
+      "href" : "https://local/zoomstack/styles/Outdoor?f=mbs"
+    }
+  } ],
+  "layers" : [ {
+    "id" : "background"
+  }, {
+    "id" : "sea shadow",
+    "type" : "geometry"
+  }, {
+    "id" : "sea",
+    "type" : "geometry"
+  }, {
+    "id" : "national-parks",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/national_parks/items"
+    }
+  }, {
+    "id" : "urban-areas",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/urban_areas/items"
+    }
+  }, {
+    "id" : "sites",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/sites/items"
+    }
+  }, {
+    "id" : "greenspace",
+    "type" : "geometry"
+  }, {
+    "id" : "greenspace outlines",
+    "type" : "geometry"
+  }, {
+    "id" : "woodland",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/woodland/items"
+    }
+  }, {
+    "id" : "contours",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/contours/items"
+    }
+  }, {
+    "id" : "surfacewater shadow",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/surfacewater/items"
+    }
+  }, {
+    "id" : "surfacewater",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/surfacewater/items"
+    }
+  }, {
+    "id" : "foreshore",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/foreshore/items"
+    }
+  }, {
+    "id" : "waterlines",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/waterlines/items"
+    }
+  }, {
+    "id" : "buildings 2D",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Restricted Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Local Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Guided Busway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Guided Busway Centreline",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Motorway",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Minor Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 B Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 A Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 0 Primary Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Local Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Minor Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 B Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 A Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Primary Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Motorway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Restricted Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Local Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Guided Busway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Guided Busway Centreline",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Motorway",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Minor Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 B Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 A Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 1 Primary Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Local Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Minor Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 B Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 A Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Primary Road Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Motorway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Restricted Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Local Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Guided Busway Casing",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Guided Busway Centreline",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Motorway",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Minor Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 B Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 A Road",
+    "type" : "geometry"
+  }, {
+    "id" : "roads 2 Primary Road",
+    "type" : "geometry"
+  }, {
+    "id" : "road Tunnels",
+    "type" : "geometry"
+  }, {
+    "id" : "rail",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/rail/items"
+    }
+  }, {
+    "id" : "rail tunnel",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/rail/items"
+    }
+  }, {
+    "id" : "buildings 3D",
+    "type" : "geometry"
+  }, {
+    "id" : "boundaries",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/boundaries/items"
+    }
+  }, {
+    "id" : "etl",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/etl/items"
+    }
+  }, {
+    "id" : "road numbers",
+    "type" : "geometry"
+  }, {
+    "id" : "road names",
+    "type" : "geometry"
+  }, {
+    "id" : "primary road numbers",
+    "type" : "geometry"
+  }, {
+    "id" : "motorway numbers",
+    "type" : "geometry"
+  }, {
+    "id" : "contour labels",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/contours/items"
+    }
+  }, {
+    "id" : "motorway junction numbers",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "greenspace names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "sites names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "landform names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "landcover names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "water names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "woodland names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "small settlement names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "suburban area names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "railwaystations",
+    "type" : "geometry"
+  }, {
+    "id" : "airports",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/airports/items"
+    }
+  }, {
+    "id" : "village and hamlet names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "town names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "city names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "national park names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "capital city names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  }, {
+    "id" : "country names",
+    "type" : "geometry",
+    "sampleData" : {
+      "rel" : "start",
+      "href" : "https://local/zoomstack/collections/names/items"
+    }
+  } ]
+}

--- a/fixtures/ogc-api/sample-data/styles/OutdoorHillshade/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/OutdoorHillshade/metadata.json
@@ -1,396 +1,485 @@
 {
-    "title" : "OS Open Zoomstack - Outdoor with Hillshade",
-    "links" : [ {
-      "rel" : "self",
-      "type" : "application/json",
-      "title" : "This document",
-      "href" : "https://local/zoomstack/styles/OutdoorHillshade/metadata?f=json"
-    }, {
-      "rel" : "alternate",
-      "type" : "text/html",
-      "title" : "This document as HTML",
-      "href" : "https://local/zoomstack/styles/OutdoorHillshade/metadata?f=html"
-    } ],
-    "id" : "OutdoorHillshade",
-    "scope" : "style",
-    "stylesheets" : [ {
-      "title" : "Mapbox",
-      "version" : "8",
-      "specification" : "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
-      "native" : true,
-      "link" : {
-        "rel" : "stylesheet",
-        "type" : "application/vnd.mapbox.style+json",
-        "title" : "Style in format 'Mapbox'",
-        "href" : "https://local/zoomstack/styles/OutdoorHillshade?f=mbs"
+  "title": "OS Open Zoomstack - Outdoor with Hillshade",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://local/zoomstack/styles/OutdoorHillshade/metadata?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://local/zoomstack/styles/OutdoorHillshade/metadata?f=html"
+    }
+  ],
+  "id": "OutdoorHillshade",
+  "scope": "style",
+  "stylesheets": [
+    {
+      "title": "Mapbox",
+      "version": "8",
+      "specification": "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.mapbox.style+json",
+        "title": "Style in format 'Mapbox'",
+        "href": "https://local/zoomstack/styles/OutdoorHillshade?f=mbs"
       }
-    } ],
-    "layers" : [ {
-      "id" : "background"
-    }, {
-      "id" : "sea shadow",
-      "type" : "geometry"
-    }, {
-      "id" : "sea",
-      "type" : "geometry"
-    }, {
-      "id" : "national-parks",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/national_parks/items"
+    }
+  ],
+  "layers": [
+    {
+      "id": "background"
+    },
+    {
+      "id": "sea shadow",
+      "type": "geometry"
+    },
+    {
+      "id": "sea",
+      "type": "geometry"
+    },
+    {
+      "id": "national-parks",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/national_parks/items"
       }
-    }, {
-      "id" : "urban-areas",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/urban_areas/items"
+    },
+    {
+      "id": "urban-areas",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/urban_areas/items"
       }
-    }, {
-      "id" : "sites",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/sites/items"
+    },
+    {
+      "id": "sites",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/sites/items"
       }
-    }, {
-      "id" : "greenspace",
-      "type" : "geometry"
-    }, {
-      "id" : "greenspace outlines",
-      "type" : "geometry"
-    }, {
-      "id" : "woodland",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/woodland/items"
+    },
+    {
+      "id": "greenspace",
+      "type": "geometry"
+    },
+    {
+      "id": "greenspace outlines",
+      "type": "geometry"
+    },
+    {
+      "id": "woodland",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/woodland/items"
       }
-    }, {
-      "id" : "Terrain"
-    }, {
-      "id" : "contours",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/contours/items"
+    },
+    {
+      "id": "Terrain"
+    },
+    {
+      "id": "contours",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/contours/items"
       }
-    }, {
-      "id" : "surfacewater shadow",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/surfacewater/items"
+    },
+    {
+      "id": "surfacewater shadow",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/surfacewater/items"
       }
-    }, {
-      "id" : "surfacewater",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/surfacewater/items"
+    },
+    {
+      "id": "surfacewater",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/surfacewater/items"
       }
-    }, {
-      "id" : "foreshore",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/foreshore/items"
+    },
+    {
+      "id": "foreshore",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/foreshore/items"
       }
-    }, {
-      "id" : "waterlines",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/waterlines/items"
+    },
+    {
+      "id": "waterlines",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/waterlines/items"
       }
-    }, {
-      "id" : "buildings 2D",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 0 Restricted Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 0 Local Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 0 Guided Busway Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 0 Guided Busway Centreline",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 0 Motorway",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 0 Minor Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 0 B Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 0 A Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 0 Primary Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Local Road Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Minor Road Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 B Road Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 A Road Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Primary Road Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Motorway Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Restricted Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Local Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Guided Busway Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Guided Busway Centreline",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Motorway",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Minor Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 B Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 A Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 1 Primary Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Local Road Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Minor Road Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 B Road Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 A Road Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Primary Road Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Motorway Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Restricted Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Local Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Guided Busway Casing",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Guided Busway Centreline",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Motorway",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Minor Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 B Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 A Road",
-      "type" : "geometry"
-    }, {
-      "id" : "roads 2 Primary Road",
-      "type" : "geometry"
-    }, {
-      "id" : "road Tunnels",
-      "type" : "geometry"
-    }, {
-      "id" : "rail",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/rail/items"
+    },
+    {
+      "id": "buildings 2D",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "road Tunnels",
+      "type": "geometry"
+    },
+    {
+      "id": "rail",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/rail/items"
       }
-    }, {
-      "id" : "rail tunnel",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/rail/items"
+    },
+    {
+      "id": "rail tunnel",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/rail/items"
       }
-    }, {
-      "id" : "buildings 3D",
-      "type" : "geometry"
-    }, {
-      "id" : "boundaries",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/boundaries/items"
+    },
+    {
+      "id": "buildings 3D",
+      "type": "geometry"
+    },
+    {
+      "id": "boundaries",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/boundaries/items"
       }
-    }, {
-      "id" : "etl",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/etl/items"
+    },
+    {
+      "id": "etl",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/etl/items"
       }
-    }, {
-      "id" : "road numbers",
-      "type" : "geometry"
-    }, {
-      "id" : "road names",
-      "type" : "geometry"
-    }, {
-      "id" : "primary road numbers",
-      "type" : "geometry"
-    }, {
-      "id" : "motorway numbers",
-      "type" : "geometry"
-    }, {
-      "id" : "contour labels",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/contours/items"
+    },
+    {
+      "id": "road numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "road names",
+      "type": "geometry"
+    },
+    {
+      "id": "primary road numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "motorway numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "contour labels",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/contours/items"
       }
-    }, {
-      "id" : "motorway junction numbers",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "motorway junction numbers",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "greenspace names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "greenspace names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "sites names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "sites names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "landform names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "landform names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "landcover names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "landcover names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "water names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "water names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "woodland names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "woodland names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "small settlement names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "small settlement names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "suburban area names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "suburban area names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "railwaystations",
-      "type" : "geometry"
-    }, {
-      "id" : "airports",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/airports/items"
+    },
+    {
+      "id": "railwaystations",
+      "type": "geometry"
+    },
+    {
+      "id": "airports",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/airports/items"
       }
-    }, {
-      "id" : "village and hamlet names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "village and hamlet names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "town names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "town names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "city names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "city names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "national park names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "national park names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "capital city names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "capital city names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    }, {
-      "id" : "country names",
-      "type" : "geometry",
-      "sampleData" : {
-        "rel" : "start",
-        "href" : "https://local/zoomstack/collections/names/items"
+    },
+    {
+      "id": "country names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "https://local/zoomstack/collections/names/items"
       }
-    } ]
-  }
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/styles/OutdoorHillshade/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/OutdoorHillshade/metadata.json
@@ -1,0 +1,396 @@
+{
+    "title" : "OS Open Zoomstack - Outdoor with Hillshade",
+    "links" : [ {
+      "rel" : "self",
+      "type" : "application/json",
+      "title" : "This document",
+      "href" : "https://local/zoomstack/styles/OutdoorHillshade/metadata?f=json"
+    }, {
+      "rel" : "alternate",
+      "type" : "text/html",
+      "title" : "This document as HTML",
+      "href" : "https://local/zoomstack/styles/OutdoorHillshade/metadata?f=html"
+    } ],
+    "id" : "OutdoorHillshade",
+    "scope" : "style",
+    "stylesheets" : [ {
+      "title" : "Mapbox",
+      "version" : "8",
+      "specification" : "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
+      "native" : true,
+      "link" : {
+        "rel" : "stylesheet",
+        "type" : "application/vnd.mapbox.style+json",
+        "title" : "Style in format 'Mapbox'",
+        "href" : "https://local/zoomstack/styles/OutdoorHillshade?f=mbs"
+      }
+    } ],
+    "layers" : [ {
+      "id" : "background"
+    }, {
+      "id" : "sea shadow",
+      "type" : "geometry"
+    }, {
+      "id" : "sea",
+      "type" : "geometry"
+    }, {
+      "id" : "national-parks",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/national_parks/items"
+      }
+    }, {
+      "id" : "urban-areas",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/urban_areas/items"
+      }
+    }, {
+      "id" : "sites",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/sites/items"
+      }
+    }, {
+      "id" : "greenspace",
+      "type" : "geometry"
+    }, {
+      "id" : "greenspace outlines",
+      "type" : "geometry"
+    }, {
+      "id" : "woodland",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/woodland/items"
+      }
+    }, {
+      "id" : "Terrain"
+    }, {
+      "id" : "contours",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/contours/items"
+      }
+    }, {
+      "id" : "surfacewater shadow",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/surfacewater/items"
+      }
+    }, {
+      "id" : "surfacewater",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/surfacewater/items"
+      }
+    }, {
+      "id" : "foreshore",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/foreshore/items"
+      }
+    }, {
+      "id" : "waterlines",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/waterlines/items"
+      }
+    }, {
+      "id" : "buildings 2D",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 0 Restricted Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 0 Local Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 0 Guided Busway Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 0 Guided Busway Centreline",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 0 Motorway",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 0 Minor Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 0 B Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 0 A Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 0 Primary Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Local Road Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Minor Road Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 B Road Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 A Road Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Primary Road Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Motorway Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Restricted Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Local Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Guided Busway Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Guided Busway Centreline",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Motorway",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Minor Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 B Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 A Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 1 Primary Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Local Road Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Minor Road Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 B Road Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 A Road Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Primary Road Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Motorway Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Restricted Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Local Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Guided Busway Casing",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Guided Busway Centreline",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Motorway",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Minor Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 B Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 A Road",
+      "type" : "geometry"
+    }, {
+      "id" : "roads 2 Primary Road",
+      "type" : "geometry"
+    }, {
+      "id" : "road Tunnels",
+      "type" : "geometry"
+    }, {
+      "id" : "rail",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/rail/items"
+      }
+    }, {
+      "id" : "rail tunnel",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/rail/items"
+      }
+    }, {
+      "id" : "buildings 3D",
+      "type" : "geometry"
+    }, {
+      "id" : "boundaries",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/boundaries/items"
+      }
+    }, {
+      "id" : "etl",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/etl/items"
+      }
+    }, {
+      "id" : "road numbers",
+      "type" : "geometry"
+    }, {
+      "id" : "road names",
+      "type" : "geometry"
+    }, {
+      "id" : "primary road numbers",
+      "type" : "geometry"
+    }, {
+      "id" : "motorway numbers",
+      "type" : "geometry"
+    }, {
+      "id" : "contour labels",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/contours/items"
+      }
+    }, {
+      "id" : "motorway junction numbers",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "greenspace names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "sites names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "landform names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "landcover names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "water names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "woodland names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "small settlement names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "suburban area names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "railwaystations",
+      "type" : "geometry"
+    }, {
+      "id" : "airports",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/airports/items"
+      }
+    }, {
+      "id" : "village and hamlet names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "town names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "city names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "national park names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "capital city names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    }, {
+      "id" : "country names",
+      "type" : "geometry",
+      "sampleData" : {
+        "rel" : "start",
+        "href" : "https://local/zoomstack/collections/names/items"
+      }
+    } ]
+  }

--- a/fixtures/ogc-api/sample-data/styles/Road/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/Road/metadata.json
@@ -1,0 +1,514 @@
+{
+  "title": "OS Open Zoomstack - Road",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "http://local/zoomstack/styles/Road/metadata?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "http://local/zoomstack/styles/Road/metadata?f=html"
+    }
+  ],
+  "id": "Road",
+  "scope": "style",
+  "stylesheets": [
+    {
+      "title": "ArcGIS",
+      "version": "n/a",
+      "specification": "https://www.esri.com/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.esri.lyr",
+        "title": "Style in format 'ArcGIS'",
+        "href": "http://local/zoomstack/styles/Road?f=lyr"
+      }
+    },
+    {
+      "title": "Mapbox",
+      "version": "8",
+      "specification": "https://docs.mapbox.com/mapbox-gl-js/style-spec/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.mapbox.style+json",
+        "title": "Style in format 'Mapbox'",
+        "href": "http://local/zoomstack/styles/Road?f=mbs"
+      }
+    }
+  ],
+  "layers": [
+    {
+      "id": "background"
+    },
+    {
+      "id": "sea",
+      "type": "geometry"
+    },
+    {
+      "id": "national-parks",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/national_parks/items"
+      }
+    },
+    {
+      "id": "urban-areas",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/urban_areas/items"
+      }
+    },
+    {
+      "id": "sites",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/sites/items"
+      }
+    },
+    {
+      "id": "greenspace",
+      "type": "geometry"
+    },
+    {
+      "id": "greenspace outlines",
+      "type": "geometry"
+    },
+    {
+      "id": "woodland",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/woodland/items"
+      }
+    },
+    {
+      "id": "contours",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/contours/items"
+      }
+    },
+    {
+      "id": "surfacewater",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/surfacewater/items"
+      }
+    },
+    {
+      "id": "surfacewater outlines",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/surfacewater/items"
+      }
+    },
+    {
+      "id": "foreshore",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/foreshore/items"
+      }
+    },
+    {
+      "id": "waterlines",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/waterlines/items"
+      }
+    },
+    {
+      "id": "buildings 2D",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 0 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 1 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Local Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Minor Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 B Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 A Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Primary Road Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Motorway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Restricted Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Local Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Guided Busway Casing",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Guided Busway Centreline",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Motorway",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Minor Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 B Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 A Road",
+      "type": "geometry"
+    },
+    {
+      "id": "roads 2 Primary Road",
+      "type": "geometry"
+    },
+    {
+      "id": "road Tunnels",
+      "type": "geometry"
+    },
+    {
+      "id": "rail",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/rail/items"
+      }
+    },
+    {
+      "id": "rail tunnel",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/rail/items"
+      }
+    },
+    {
+      "id": "buildings 3D",
+      "type": "geometry"
+    },
+    {
+      "id": "boundaries",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/boundaries/items"
+      }
+    },
+    {
+      "id": "etl",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/etl/items"
+      }
+    },
+    {
+      "id": "road numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "road names",
+      "type": "geometry"
+    },
+    {
+      "id": "primary road numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "motorway numbers",
+      "type": "geometry"
+    },
+    {
+      "id": "contour labels",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/contours/items"
+      }
+    },
+    {
+      "id": "motorway junction numbers",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "greenspace names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "sites names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "landform names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "landcover names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "water names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "woodland names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "small settlement names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "suburban area names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "railwaystations",
+      "type": "geometry"
+    },
+    {
+      "id": "airports",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/airports/items"
+      }
+    },
+    {
+      "id": "village and hamlet names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "town names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "city names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "national park names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "capital city names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    },
+    {
+      "id": "country names",
+      "type": "geometry",
+      "sampleData": {
+        "rel": "start",
+        "href": "http://local/zoomstack/collections/names/items"
+      }
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data/styles/Tritanopia/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/Tritanopia/metadata.json
@@ -1,0 +1,28 @@
+{
+  "title" : "Tritanopia",
+  "links" : [ {
+    "rel" : "self",
+    "type" : "application/json",
+    "title" : "This document",
+    "href" : "https://local/zoomstack/styles/Tritanopia/metadata?f=json"
+  }, {
+    "rel" : "alternate",
+    "type" : "text/html",
+    "title" : "This document as HTML",
+    "href" : "https://local/zoomstack/styles/Tritanopia/metadata?f=html"
+  } ],
+  "id" : "Tritanopia",
+  "scope" : "style",
+  "stylesheets" : [ {
+    "title" : "ArcGIS",
+    "version" : "n/a",
+    "specification" : "https://www.esri.com/",
+    "native" : true,
+    "link" : {
+      "rel" : "stylesheet",
+      "type" : "application/vnd.esri.lyr",
+      "title" : "Style in format 'ArcGIS'",
+      "href" : "https://local/zoomstack/styles/Tritanopia?f=lyr"
+    }
+  } ]
+}

--- a/fixtures/ogc-api/sample-data/styles/Tritanopia/metadata.json
+++ b/fixtures/ogc-api/sample-data/styles/Tritanopia/metadata.json
@@ -1,28 +1,33 @@
 {
-  "title" : "Tritanopia",
-  "links" : [ {
-    "rel" : "self",
-    "type" : "application/json",
-    "title" : "This document",
-    "href" : "https://local/zoomstack/styles/Tritanopia/metadata?f=json"
-  }, {
-    "rel" : "alternate",
-    "type" : "text/html",
-    "title" : "This document as HTML",
-    "href" : "https://local/zoomstack/styles/Tritanopia/metadata?f=html"
-  } ],
-  "id" : "Tritanopia",
-  "scope" : "style",
-  "stylesheets" : [ {
-    "title" : "ArcGIS",
-    "version" : "n/a",
-    "specification" : "https://www.esri.com/",
-    "native" : true,
-    "link" : {
-      "rel" : "stylesheet",
-      "type" : "application/vnd.esri.lyr",
-      "title" : "Style in format 'ArcGIS'",
-      "href" : "https://local/zoomstack/styles/Tritanopia?f=lyr"
+  "title": "Tritanopia",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://local/zoomstack/styles/Tritanopia/metadata?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://local/zoomstack/styles/Tritanopia/metadata?f=html"
     }
-  } ]
+  ],
+  "id": "Tritanopia",
+  "scope": "style",
+  "stylesheets": [
+    {
+      "title": "ArcGIS",
+      "version": "n/a",
+      "specification": "https://www.esri.com/",
+      "native": true,
+      "link": {
+        "rel": "stylesheet",
+        "type": "application/vnd.esri.lyr",
+        "title": "Style in format 'ArcGIS'",
+        "href": "https://local/zoomstack/styles/Tritanopia?f=lyr"
+      }
+    }
+  ]
 }

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -1944,22 +1944,9 @@ The document at http://local/nonexisting?f=json could not be fetched.`
     beforeEach(() => {
       endpoint = new OgcApiEndpoint('http://local/sample-data/');
     });
-    describe('#listAllStyles', () => {
-      it('returns a list of style ids', async () => {
-        await expect(endpoint.listAllStyles).resolves.toEqual([
-          'Deuteranopia',
-          'Light',
-          'Night',
-          'Outdoor',
-          'OutdoorHillshade',
-          'Road',
-          'Tritanopia',
-        ]);
-      });
-    });
     describe('#allStyles', () => {
       it('returns a list of styles', async () => {
-        await expect(endpoint.allStyles).resolves.toEqual([
+        await expect(endpoint.allStyles()).resolves.toEqual([
           {
             title: 'Deuteranopia',
             id: 'Deuteranopia',
@@ -2010,7 +1997,71 @@ The document at http://local/nonexisting?f=json could not be fetched.`
         ]);
       });
     });
-    describe('#getStyleMetadata', () => {
+    describe('#allStyles for a given collection', () => {
+      it('returns a list of styles', async () => {
+        await expect(endpoint.allStyles('airports')).resolves.toEqual([
+          {
+            title: 'Deuteranopia',
+            id: 'Deuteranopia',
+            formats: [
+              'application/vnd.qgis.qml',
+              'application/vnd.ogc.sld+xml;version=1.0',
+            ],
+          },
+          {
+            title: 'Light',
+            id: 'Light',
+            formats: [
+              'application/vnd.qgis.qml',
+              'application/vnd.ogc.sld+xml;version=1.0',
+              'application/vnd.mapbox.style+json',
+            ],
+          },
+          {
+            title: 'Night',
+            id: 'Night',
+            formats: [
+              'application/vnd.qgis.qml',
+              'application/vnd.ogc.sld+xml;version=1.0',
+              'application/vnd.mapbox.style+json',
+            ],
+          },
+          {
+            title: 'Outdoor',
+            id: 'Outdoor',
+            formats: [
+              'application/vnd.qgis.qml',
+              'application/vnd.ogc.sld+xml;version=1.0',
+              'application/vnd.mapbox.style+json',
+            ],
+          },
+          {
+            title: 'Road',
+            id: 'Road',
+            formats: [
+              'application/vnd.qgis.qml',
+              'application/vnd.ogc.sld+xml;version=1.0',
+              'application/vnd.mapbox.style+json',
+            ],          },
+          {
+            title: 'Tritanopia',
+            id: 'Tritanopia',
+            formats: [
+              'application/vnd.qgis.qml',
+              'application/vnd.ogc.sld+xml;version=1.0',
+            ],
+          },
+          {
+            title: 'OS Open Zoomstack - Outdoor with Hillshade',
+            id: 'OutdoorHillshade',
+            formats: [
+              'application/vnd.mapbox.style+json',
+            ],
+          },
+        ]);
+      });
+    });
+    describe('#getStyle', () => {
       it('returns style metadata', async () => {
         await expect(endpoint.getStyle('Deuteranopia')).resolves.toEqual({
           title: 'Deuteranopia',
@@ -2034,6 +2085,45 @@ The document at http://local/nonexisting?f=json could not be fetched.`
         });
       });
     });
+    describe('#getStyle for a given collection', () => {
+      it('returns style metadata', async () => {
+        await expect(endpoint.getStyle('Tritanopia', 'airports')).resolves.toEqual({
+          title: 'Tritanopia',
+          id: 'Tritanopia',
+          scope: 'style',
+          stylesheetFormats: [
+            'application/vnd.qgis.qml',
+            'application/vnd.ogc.sld+xml;version=1.0'
+          ],
+          stylesheets: [
+            {
+              title: 'QGIS',
+              version: '3.16',
+              specification: 'https://docs.qgis.org/3.16/en/docs/user_manual/appendices/qgis_file_formats.html#qml-the-qgis-style-file-format',
+              native: true,
+              link: {
+                rel: 'stylesheet',
+                type: 'application/vnd.qgis.qml',
+                title: "Style in format 'QGIS'",
+                href: 'https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=qml',
+              },
+            },
+            {
+              title: 'SLD 1.0',
+              version: '1.0',
+              specification: 'https://www.ogc.org/standards/sld',
+              native: true,
+              link: {
+                rel: 'stylesheet',
+                type: 'application/vnd.ogc.sld+xml;version=1.0',
+                title: "Style in format 'SLD 1.0'",
+                href: 'https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=sld10',
+              },
+            },
+          ],
+        });
+      });
+    });
     describe('#getStylesheetUrl', () => {
       it('returns the correct stylesheet URL', async () => {
         await expect(
@@ -2041,12 +2131,21 @@ The document at http://local/nonexisting?f=json could not be fetched.`
         ).resolves.toEqual('http://local/zoomstack/styles/Deuteranopia?f=lyr');
       });
     });
-    describe('#getStylesheetUrl with type html', () => {
+    describe('#getStylesheetUrl with type Mapbox', () => {
       it('returns the correct stylesheet URL', async () => {
         await expect(
-          endpoint.getStylesheetUrl('Road', 'text/html')
+          endpoint.getStylesheetUrl('Road', 'application/vnd.mapbox.style+json')
         ).resolves.toEqual(
-          'https://my.server.org/sample-data/styles/Road?f=html'
+          'http://local/zoomstack/styles/Road?f=mbs'
+        );
+      });
+    });
+    describe('#getStylesheetUrl for a given collection', () => {
+      it('returns the correct stylesheet URL', async () => {
+        await expect(
+          endpoint.getStylesheetUrl('Tritanopia', 'application/vnd.ogc.sld+xml;version=1.0', 'airports')
+        ).resolves.toEqual(
+          'https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=sld10'
         );
       });
     });

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -1944,7 +1944,7 @@ The document at http://local/nonexisting?f=json could not be fetched.`
     beforeEach(() => {
       endpoint = new OgcApiEndpoint('http://local/sample-data/');
     });
-    describe('#listAllStyles', () => { 
+    describe('#listAllStyles', () => {
       it('returns a list of style ids', async () => {
         await expect(endpoint.listAllStyles).resolves.toEqual([
           'Deuteranopia',
@@ -1953,101 +1953,119 @@ The document at http://local/nonexisting?f=json could not be fetched.`
           'Outdoor',
           'OutdoorHillshade',
           'Road',
-          'Tritanopia'
+          'Tritanopia',
         ]);
       });
     });
-    describe('#allStyles', () => { 
+    describe('#allStyles', () => {
       it('returns a list of styles', async () => {
         await expect(endpoint.allStyles).resolves.toEqual([
           {
-            "title": "Deuteranopia",
-            "id": "Deuteranopia",
-            "formats": ["application/vnd.esri.lyr"]
+            title: 'Deuteranopia',
+            id: 'Deuteranopia',
+            formats: ['application/vnd.esri.lyr'],
           },
           {
-            "title": "OS Open Zoomstack - Light",
-            "id": "Light",
-            "formats": ["application/vnd.esri.lyr", "text/html", "application/vnd.mapbox.style+json"]
+            title: 'OS Open Zoomstack - Light',
+            id: 'Light',
+            formats: [
+              'application/vnd.esri.lyr',
+              'text/html',
+              'application/vnd.mapbox.style+json',
+            ],
           },
           {
-            "title": "OS Open Zoomstack - Night",
-            "id": "Night",
-            "formats": ["application/vnd.esri.lyr", "text/html", "application/vnd.mapbox.style+json"]
+            title: 'OS Open Zoomstack - Night',
+            id: 'Night',
+            formats: [
+              'application/vnd.esri.lyr',
+              'text/html',
+              'application/vnd.mapbox.style+json',
+            ],
           },
           {
-            "title": "OS Open Zoomstack - Outdoor",
-            "id": "Outdoor",
-            "formats": ["application/vnd.esri.lyr", "text/html", "application/vnd.mapbox.style+json"]
+            title: 'OS Open Zoomstack - Outdoor',
+            id: 'Outdoor',
+            formats: [
+              'application/vnd.esri.lyr',
+              'text/html',
+              'application/vnd.mapbox.style+json',
+            ],
           },
           {
-            "title": "OS Open Zoomstack - Outdoor with Hillshade",
-            "id": "OutdoorHillshade",
-            "formats": ["text/html", "application/vnd.mapbox.style+json"]
+            title: 'OS Open Zoomstack - Outdoor with Hillshade',
+            id: 'OutdoorHillshade',
+            formats: ['text/html', 'application/vnd.mapbox.style+json'],
           },
           {
-            "title": "OS Open Zoomstack - Road",
-            "id": "Road",
-            "formats": ["application/vnd.esri.lyr", "text/html", "application/vnd.mapbox.style+json"]
+            title: 'OS Open Zoomstack - Road',
+            id: 'Road',
+            formats: [
+              'application/vnd.esri.lyr',
+              'text/html',
+              'application/vnd.mapbox.style+json',
+            ],
           },
           {
-            "title": "Tritanopia",
-            "id": "Tritanopia",
-            "formats": ["application/vnd.esri.lyr"]
-          }
+            title: 'Tritanopia',
+            id: 'Tritanopia',
+            formats: ['application/vnd.esri.lyr'],
+          },
         ]);
       });
     });
-    describe('#getStyleMetadata', () => { 
+    describe('#getStyleMetadata', () => {
       it('returns style metadata', async () => {
-        await expect(endpoint.getStyleMetadata('Deuteranopia')).resolves.toEqual({
-          "title": "Deuteranopia",
-          "links": [
+        await expect(
+          endpoint.getStyleMetadata('Deuteranopia')
+        ).resolves.toEqual({
+          title: 'Deuteranopia',
+          links: [
             {
-              "rel": "self",
-              "type": "application/json",
-              "title": "This document",
-              "href": "http://local/zoomstack/styles/Deuteranopia/metadata?f=json"
+              rel: 'self',
+              type: 'application/json',
+              title: 'This document',
+              href: 'http://local/zoomstack/styles/Deuteranopia/metadata?f=json',
             },
             {
-              "rel": "alternate",
-              "type": "text/html",
-              "title": "This document as HTML",
-              "href": "http://local/zoomstack/styles/Deuteranopia/metadata?f=html"
-            }
+              rel: 'alternate',
+              type: 'text/html',
+              title: 'This document as HTML',
+              href: 'http://local/zoomstack/styles/Deuteranopia/metadata?f=html',
+            },
           ],
-          "id": "Deuteranopia",
-          "scope": "style",
-          "stylesheetFormats": [
-            "application/vnd.esri.lyr",
-          ],
-          "stylesheets": [
+          id: 'Deuteranopia',
+          scope: 'style',
+          stylesheetFormats: ['application/vnd.esri.lyr'],
+          stylesheets: [
             {
-              "title": "ArcGIS",
-              "version": "n/a",
-              "specification": "https://www.esri.com/",
-              "native": true,
-              "link": {
-                "rel": "stylesheet",
-                "type": "application/vnd.esri.lyr",
-                "title": "Style in format 'ArcGIS'",
-                "href": "http://local/zoomstack/styles/Deuteranopia?f=lyr"
-              }
-            }
-          ]
+              title: 'ArcGIS',
+              version: 'n/a',
+              specification: 'https://www.esri.com/',
+              native: true,
+              link: {
+                rel: 'stylesheet',
+                type: 'application/vnd.esri.lyr',
+                title: "Style in format 'ArcGIS'",
+                href: 'http://local/zoomstack/styles/Deuteranopia?f=lyr',
+              },
+            },
+          ],
         });
       });
     });
-    describe('#getStylesheetUrl', () => { 
+    describe('#getStylesheetUrl', () => {
       it('returns the correct stylesheet URL', async () => {
-        await expect(endpoint.getStylesheetUrl('Deuteranopia', 'application/vnd.esri.lyr')).resolves.toEqual(
-          'http://local/zoomstack/styles/Deuteranopia?f=lyr'
-        );
+        await expect(
+          endpoint.getStylesheetUrl('Deuteranopia', 'application/vnd.esri.lyr')
+        ).resolves.toEqual('http://local/zoomstack/styles/Deuteranopia?f=lyr');
       });
     });
-    describe('#getStylesheetUrl with type html', () => { 
+    describe('#getStylesheetUrl with type html', () => {
       it('returns the correct stylesheet URL', async () => {
-        await expect(endpoint.getStylesheetUrl('Road', 'text/html')).resolves.toEqual(
+        await expect(
+          endpoint.getStylesheetUrl('Road', 'text/html')
+        ).resolves.toEqual(
           'https://my.server.org/sample-data/styles/Road?f=html'
         );
       });

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -1992,9 +1992,7 @@ The document at http://local/nonexisting?f=json could not be fetched.`
           {
             title: 'OS Open Zoomstack - Outdoor with Hillshade',
             id: 'OutdoorHillshade',
-            formats: [
-              'application/vnd.mapbox.style+json'
-            ],
+            formats: ['application/vnd.mapbox.style+json'],
           },
           {
             title: 'OS Open Zoomstack - Road',
@@ -2014,9 +2012,7 @@ The document at http://local/nonexisting?f=json could not be fetched.`
     });
     describe('#getStyleMetadata', () => {
       it('returns style metadata', async () => {
-        await expect(
-          endpoint.getStyle('Deuteranopia')
-        ).resolves.toEqual({
+        await expect(endpoint.getStyle('Deuteranopia')).resolves.toEqual({
           title: 'Deuteranopia',
           id: 'Deuteranopia',
           scope: 'style',

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -1970,7 +1970,6 @@ The document at http://local/nonexisting?f=json could not be fetched.`
             id: 'Light',
             formats: [
               'application/vnd.esri.lyr',
-              'text/html',
               'application/vnd.mapbox.style+json',
             ],
           },
@@ -1979,7 +1978,6 @@ The document at http://local/nonexisting?f=json could not be fetched.`
             id: 'Night',
             formats: [
               'application/vnd.esri.lyr',
-              'text/html',
               'application/vnd.mapbox.style+json',
             ],
           },
@@ -1988,21 +1986,21 @@ The document at http://local/nonexisting?f=json could not be fetched.`
             id: 'Outdoor',
             formats: [
               'application/vnd.esri.lyr',
-              'text/html',
               'application/vnd.mapbox.style+json',
             ],
           },
           {
             title: 'OS Open Zoomstack - Outdoor with Hillshade',
             id: 'OutdoorHillshade',
-            formats: ['text/html', 'application/vnd.mapbox.style+json'],
+            formats: [
+              'application/vnd.mapbox.style+json'
+            ],
           },
           {
             title: 'OS Open Zoomstack - Road',
             id: 'Road',
             formats: [
               'application/vnd.esri.lyr',
-              'text/html',
               'application/vnd.mapbox.style+json',
             ],
           },
@@ -2020,20 +2018,6 @@ The document at http://local/nonexisting?f=json could not be fetched.`
           endpoint.getStyle('Deuteranopia')
         ).resolves.toEqual({
           title: 'Deuteranopia',
-          links: [
-            {
-              rel: 'self',
-              type: 'application/json',
-              title: 'This document',
-              href: 'http://local/zoomstack/styles/Deuteranopia/metadata?f=json',
-            },
-            {
-              rel: 'alternate',
-              type: 'text/html',
-              title: 'This document as HTML',
-              href: 'http://local/zoomstack/styles/Deuteranopia/metadata?f=html',
-            },
-          ],
           id: 'Deuteranopia',
           scope: 'style',
           stylesheetFormats: ['application/vnd.esri.lyr'],

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -2042,7 +2042,8 @@ The document at http://local/nonexisting?f=json could not be fetched.`
               'application/vnd.qgis.qml',
               'application/vnd.ogc.sld+xml;version=1.0',
               'application/vnd.mapbox.style+json',
-            ],          },
+            ],
+          },
           {
             title: 'Tritanopia',
             id: 'Tritanopia',
@@ -2054,9 +2055,7 @@ The document at http://local/nonexisting?f=json could not be fetched.`
           {
             title: 'OS Open Zoomstack - Outdoor with Hillshade',
             id: 'OutdoorHillshade',
-            formats: [
-              'application/vnd.mapbox.style+json',
-            ],
+            formats: ['application/vnd.mapbox.style+json'],
           },
         ]);
       });
@@ -2087,19 +2086,22 @@ The document at http://local/nonexisting?f=json could not be fetched.`
     });
     describe('#getStyle for a given collection', () => {
       it('returns style metadata', async () => {
-        await expect(endpoint.getStyle('Tritanopia', 'airports')).resolves.toEqual({
+        await expect(
+          endpoint.getStyle('Tritanopia', 'airports')
+        ).resolves.toEqual({
           title: 'Tritanopia',
           id: 'Tritanopia',
           scope: 'style',
           stylesheetFormats: [
             'application/vnd.qgis.qml',
-            'application/vnd.ogc.sld+xml;version=1.0'
+            'application/vnd.ogc.sld+xml;version=1.0',
           ],
           stylesheets: [
             {
               title: 'QGIS',
               version: '3.16',
-              specification: 'https://docs.qgis.org/3.16/en/docs/user_manual/appendices/qgis_file_formats.html#qml-the-qgis-style-file-format',
+              specification:
+                'https://docs.qgis.org/3.16/en/docs/user_manual/appendices/qgis_file_formats.html#qml-the-qgis-style-file-format',
               native: true,
               link: {
                 rel: 'stylesheet',
@@ -2135,15 +2137,17 @@ The document at http://local/nonexisting?f=json could not be fetched.`
       it('returns the correct stylesheet URL', async () => {
         await expect(
           endpoint.getStylesheetUrl('Road', 'application/vnd.mapbox.style+json')
-        ).resolves.toEqual(
-          'http://local/zoomstack/styles/Road?f=mbs'
-        );
+        ).resolves.toEqual('http://local/zoomstack/styles/Road?f=mbs');
       });
     });
     describe('#getStylesheetUrl for a given collection', () => {
       it('returns the correct stylesheet URL', async () => {
         await expect(
-          endpoint.getStylesheetUrl('Tritanopia', 'application/vnd.ogc.sld+xml;version=1.0', 'airports')
+          endpoint.getStylesheetUrl(
+            'Tritanopia',
+            'application/vnd.ogc.sld+xml;version=1.0',
+            'airports'
+          )
         ).resolves.toEqual(
           'https://my.server.org/sample-data/collections/airports/styles/Tritanopia?f=sld10'
         );

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -2017,7 +2017,7 @@ The document at http://local/nonexisting?f=json could not be fetched.`
     describe('#getStyleMetadata', () => {
       it('returns style metadata', async () => {
         await expect(
-          endpoint.getStyleMetadata('Deuteranopia')
+          endpoint.getStyle('Deuteranopia')
         ).resolves.toEqual({
           title: 'Deuteranopia',
           links: [

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -1939,4 +1939,118 @@ The document at http://local/nonexisting?f=json could not be fetched.`
       });
     });
   });
+
+  describe('endpoint with styles', () => {
+    beforeEach(() => {
+      endpoint = new OgcApiEndpoint('http://local/sample-data/');
+    });
+    describe('#listAllStyles', () => { 
+      it('returns a list of style ids', async () => {
+        await expect(endpoint.listAllStyles).resolves.toEqual([
+          'Deuteranopia',
+          'Light',
+          'Night',
+          'Outdoor',
+          'OutdoorHillshade',
+          'Road',
+          'Tritanopia'
+        ]);
+      });
+    });
+    describe('#allStyles', () => { 
+      it('returns a list of styles', async () => {
+        await expect(endpoint.allStyles).resolves.toEqual([
+          {
+            "title": "Deuteranopia",
+            "id": "Deuteranopia",
+            "formats": ["application/vnd.esri.lyr"]
+          },
+          {
+            "title": "OS Open Zoomstack - Light",
+            "id": "Light",
+            "formats": ["application/vnd.esri.lyr", "text/html", "application/vnd.mapbox.style+json"]
+          },
+          {
+            "title": "OS Open Zoomstack - Night",
+            "id": "Night",
+            "formats": ["application/vnd.esri.lyr", "text/html", "application/vnd.mapbox.style+json"]
+          },
+          {
+            "title": "OS Open Zoomstack - Outdoor",
+            "id": "Outdoor",
+            "formats": ["application/vnd.esri.lyr", "text/html", "application/vnd.mapbox.style+json"]
+          },
+          {
+            "title": "OS Open Zoomstack - Outdoor with Hillshade",
+            "id": "OutdoorHillshade",
+            "formats": ["text/html", "application/vnd.mapbox.style+json"]
+          },
+          {
+            "title": "OS Open Zoomstack - Road",
+            "id": "Road",
+            "formats": ["application/vnd.esri.lyr", "text/html", "application/vnd.mapbox.style+json"]
+          },
+          {
+            "title": "Tritanopia",
+            "id": "Tritanopia",
+            "formats": ["application/vnd.esri.lyr"]
+          }
+        ]);
+      });
+    });
+    describe('#getStyleMetadata', () => { 
+      it('returns style metadata', async () => {
+        await expect(endpoint.getStyleMetadata('Deuteranopia')).resolves.toEqual({
+          "title": "Deuteranopia",
+          "links": [
+            {
+              "rel": "self",
+              "type": "application/json",
+              "title": "This document",
+              "href": "http://local/zoomstack/styles/Deuteranopia/metadata?f=json"
+            },
+            {
+              "rel": "alternate",
+              "type": "text/html",
+              "title": "This document as HTML",
+              "href": "http://local/zoomstack/styles/Deuteranopia/metadata?f=html"
+            }
+          ],
+          "id": "Deuteranopia",
+          "scope": "style",
+          "stylesheetFormats": [
+            "application/vnd.esri.lyr",
+          ],
+          "stylesheets": [
+            {
+              "title": "ArcGIS",
+              "version": "n/a",
+              "specification": "https://www.esri.com/",
+              "native": true,
+              "link": {
+                "rel": "stylesheet",
+                "type": "application/vnd.esri.lyr",
+                "title": "Style in format 'ArcGIS'",
+                "href": "http://local/zoomstack/styles/Deuteranopia?f=lyr"
+              }
+            }
+          ]
+        });
+      });
+    });
+    describe('#getStylesheetUrl', () => { 
+      it('returns the correct stylesheet URL', async () => {
+        await expect(endpoint.getStylesheetUrl('Deuteranopia', 'application/vnd.esri.lyr')).resolves.toEqual(
+          'http://local/zoomstack/styles/Deuteranopia?f=lyr'
+        );
+      });
+    });
+    describe('#getStylesheetUrl with type html', () => { 
+      it('returns the correct stylesheet URL', async () => {
+        await expect(endpoint.getStylesheetUrl('Road', 'text/html')).resolves.toEqual(
+          'https://my.server.org/sample-data/styles/Road?f=html'
+        );
+      });
+    });
+  });
 });

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -4,10 +4,13 @@ import {
   checkStyleConformance,
   checkTileConformance,
   parseBaseCollectionInfo,
+  parseBaseStyleMetadata,
   parseCollectionParameters,
   parseCollections,
   parseConformance,
   parseEndpointInfo,
+  parseStyles,
+  parseStylesAsList,
   parseTileMatrixSets,
 } from './info.js';
 import {
@@ -16,6 +19,9 @@ import {
   OgcApiCollectionItem,
   OgcApiDocument,
   OgcApiEndpointInfo,
+  OgcApiStyleMetadata,
+  OgcApiStylesDocument,
+  StyleItem,
   TileMatrixSet,
 } from './model.js';
 import {
@@ -45,6 +51,7 @@ export default class OgcApiEndpoint {
   private conformance_: Promise<OgcApiDocument>;
   private data_: Promise<OgcApiDocument>;
   private tileMatrixSetsFull_: Promise<TileMatrixSet[]>;
+  private styles_: Promise<OgcApiStylesDocument>;
 
   private get root(): Promise<OgcApiDocument> {
     if (!this.root_) {
@@ -105,6 +112,20 @@ ${e.message}`);
       });
     }
     return this.tileMatrixSetsFull_;
+  }
+
+  private get styles(): Promise<OgcApiStylesDocument> {
+    if (!this.styles_) {
+      this.styles_ = this.root.then(async (root) => {
+        if (!(await this.hasStyles)) return undefined;
+        return fetchLink(
+          root,
+          ['styles', 'http://www.opengis.net/def/rel/ogc/1.0/styles'],
+          this.baseUrl
+        ) as unknown as OgcApiStylesDocument;
+      });
+    }
+    return this.styles_;
   }
 
   /**
@@ -247,6 +268,17 @@ ${e.message}`);
         // otherwise build a URL for the collection
         return fetchDocument(`${await this.collectionsUrl}/${collectionId}`);
       });
+  }
+
+  private async getStyleMetadataDocument(styleId: string): Promise<OgcApiDocument> {
+    const styleData = await this.styles;
+    if (!styleData.styles.some(style => style.id === styleId)) {
+      throw new EndpointError(`Style not found: "${styleId}".`);
+    }
+    const styleDoc = (styleData?.styles)?.find(
+      (style) => style.id === styleId
+    );
+    return await fetchLink(styleDoc as OgcApiDocument, 'describedby', this.baseUrl);
   }
 
   /**
@@ -559,5 +591,54 @@ ${e.message}`);
         console.error('Error fetching collection tileset URL:', error.message);
         throw error;
       });
+  }
+
+  /**
+   * A Promise which resolves to an array of all style identifiers as strings.
+   */
+  get listAllStyles(): Promise<string[]> {
+    return this.styles.then(parseStylesAsList());
+  }
+
+  /**
+   * A Promise which resolves to an array of all style items. This includes the supported style formats.
+   */
+  get allStyles(): Promise<StyleItem[]> {
+    return this.styles.then(parseStyles());
+  }
+
+  /**
+   * Returns a promise resolving to a document describing the style metadata.
+   * @param styleId The style identifier
+   */
+  async getStyleMetadata(styleId: string): Promise<OgcApiStyleMetadata> {
+    const metadataDoc = await this.getStyleMetadataDocument(styleId);
+    return parseBaseStyleMetadata(metadataDoc as OgcApiStyleMetadata);
+  }
+
+  /**
+   * Returns a promise resolving to a stylesheet URL for a given style and type.
+   * @param styleId The style identifier
+   * @param mimeType Stylesheet MIME type.
+   */
+  async getStylesheetUrl(
+    styleId: string,
+    mimeType: string
+  ): Promise<string> {
+    const metadataDoc = await this.getStyleMetadataDocument(styleId);
+    const urlFromMetadata = (metadataDoc as OgcApiStyleMetadata).stylesheets.find(
+      s => s.link.type === mimeType && s.link.rel === 'stylesheet'
+    )?.link?.href;
+
+    if (!urlFromMetadata) {
+      // fallback which retrieves the URL from the style document itself
+      const style = (await this.styles).styles?.find(style => style.id === styleId);
+      const urlFromStyle = getLinkUrl(style as unknown as OgcApiDocument, 'stylesheet', this.baseUrl, mimeType);
+      if (!urlFromStyle) {
+        throw new EndpointError("Could not find stylesheet URL for given style ID and type.");
+      }
+      return urlFromStyle;
+    }
+    return urlFromMetadata;
   }
 }

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -278,7 +278,13 @@ ${e.message}`);
     const styleDoc = (styleData?.styles)?.find(
       (style) => style.id === styleId
     );
-    return await fetchLink(styleDoc as OgcApiDocument, 'describedby', this.baseUrl);
+    try {
+      return await fetchLink(styleDoc as OgcApiDocument, 'describedby', this.baseUrl);
+    } catch (error) {
+      throw new EndpointError(
+        `Could not get metadata: there is no relation of type "describedby" for style "${styleId}".`
+      );
+    }
   }
 
   /**
@@ -619,7 +625,7 @@ ${e.message}`);
   /**
    * Returns a promise resolving to a stylesheet URL for a given style and type.
    * @param styleId The style identifier
-   * @param mimeType Stylesheet MIME type.
+   * @param mimeType Stylesheet MIME type
    */
   async getStylesheetUrl(
     styleId: string,

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -609,9 +609,13 @@ ${e.message}`);
    */
   get allStyles(): Promise<StyleItem[]> {
     return this.styles.then(async (stylesDoc) => {
-      const metadataPromises = stylesDoc.styles.map(style => this.getStyleMetadataDocument(style.id));
-      return Promise.all(metadataPromises).then(results => {
-        return results.map(r => parseStyleMetadataAsList(r as OgcApiStyleMetadata));
+      const metadataPromises = stylesDoc.styles.map((style) =>
+        this.getStyleMetadataDocument(style.id)
+      );
+      return Promise.all(metadataPromises).then((results) => {
+        return results.map((r) =>
+          parseStyleMetadataAsList(r as OgcApiStyleMetadata)
+        );
       });
     });
   }

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -4,12 +4,12 @@ import {
   checkStyleConformance,
   checkTileConformance,
   parseBaseCollectionInfo,
-  parseBaseStyleMetadata,
+  parseStyleMetadata,
   parseCollectionParameters,
   parseCollections,
   parseConformance,
   parseEndpointInfo,
-  parseStyles,
+  parseStyleMetadataAsList,
   parseStylesAsList,
   parseTileMatrixSets,
 } from './info.js';
@@ -608,7 +608,12 @@ ${e.message}`);
    * A Promise which resolves to an array of all style items. This includes the supported style formats.
    */
   get allStyles(): Promise<StyleItem[]> {
-    return this.styles.then(parseStyles());
+    return this.styles.then(async (stylesDoc) => {
+      const metadataPromises = stylesDoc.styles.map(style => this.getStyleMetadataDocument(style.id));
+      return Promise.all(metadataPromises).then(results => {
+        return results.map(r => parseStyleMetadataAsList(r as OgcApiStyleMetadata));
+      });
+    });
   }
 
   /**
@@ -622,7 +627,7 @@ ${e.message}`);
         `Could not get style metadata: there is no relation of type "describedby" for style "${styleId}".`
       );
     }
-    return parseBaseStyleMetadata(metadataDoc as OgcApiStyleMetadata);
+    return parseStyleMetadata(metadataDoc as OgcApiStyleMetadata);
   }
 
   /**

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -270,15 +270,15 @@ ${e.message}`);
       });
   }
 
-  private async getStyleMetadataDocument(styleId: string): Promise<OgcApiDocument> {
+  private async getStyleMetadataDocument(
+    styleId: string
+  ): Promise<OgcApiDocument> {
     const styleData = await this.styles;
-    if (!styleData.styles.some(style => style.id === styleId)) {
+    if (!styleData.styles.some((style) => style.id === styleId)) {
       throw new EndpointError(`Style not found: "${styleId}".`);
     }
-    const styleDoc = (styleData?.styles)?.find(
-      (style) => style.id === styleId
-    );
-    if (hasLinks(styleDoc as OgcApiDocument, ['describedby'])){
+    const styleDoc = styleData?.styles?.find((style) => style.id === styleId);
+    if (hasLinks(styleDoc as OgcApiDocument, ['describedby'])) {
       return fetchLink(styleDoc as OgcApiDocument, 'describedby', this.baseUrl);
     } else {
       return null;
@@ -630,21 +630,29 @@ ${e.message}`);
    * @param styleId The style identifier
    * @param mimeType Stylesheet MIME type
    */
-  async getStylesheetUrl(
-    styleId: string,
-    mimeType: string
-  ): Promise<string> {
+  async getStylesheetUrl(styleId: string, mimeType: string): Promise<string> {
     const metadataDoc = await this.getStyleMetadataDocument(styleId);
-    const urlFromMetadata = (metadataDoc as OgcApiStyleMetadata)?.stylesheets?.find(
-      s => s.link.type === mimeType && s.link.rel === 'stylesheet'
+    const urlFromMetadata = (
+      metadataDoc as OgcApiStyleMetadata
+    )?.stylesheets?.find(
+      (s) => s.link.type === mimeType && s.link.rel === 'stylesheet'
     )?.link?.href;
 
     if (!urlFromMetadata) {
       // fallback which retrieves the URL from the style document itself
-      const style = (await this.styles).styles?.find(style => style.id === styleId);
-      const urlFromStyle = getLinkUrl(style as unknown as OgcApiDocument, 'stylesheet', this.baseUrl, mimeType);
+      const style = (await this.styles).styles?.find(
+        (style) => style.id === styleId
+      );
+      const urlFromStyle = getLinkUrl(
+        style as unknown as OgcApiDocument,
+        'stylesheet',
+        this.baseUrl,
+        mimeType
+      );
       if (!urlFromStyle) {
-        throw new EndpointError("Could not find stylesheet URL for given style ID and type.");
+        throw new EndpointError(
+          'Could not find stylesheet URL for given style ID and type.'
+        );
       }
       return urlFromStyle;
     }

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -4,12 +4,12 @@ import {
   checkStyleConformance,
   checkTileConformance,
   parseBaseCollectionInfo,
-  parseStyleMetadata,
+  parseFullStyleInfo,
   parseCollectionParameters,
   parseCollections,
   parseConformance,
   parseEndpointInfo,
-  parseStyleMetadataAsList,
+  parseBasicStyleInfo,
   parseStylesAsList,
   parseTileMatrixSets,
 } from './info.js';
@@ -614,7 +614,7 @@ ${e.message}`);
       );
       return Promise.all(metadataPromises).then((results) => {
         return results.map((r) =>
-          parseStyleMetadataAsList(r as OgcApiStyleMetadata)
+          parseBasicStyleInfo(r as OgcApiStyleMetadata)
         );
       });
     });
@@ -631,7 +631,7 @@ ${e.message}`);
         `Could not get style metadata: there is no relation of type "describedby" for style "${styleId}".`
       );
     }
-    return parseStyleMetadata(metadataDoc as OgcApiStyleMetadata);
+    return parseFullStyleInfo(metadataDoc as OgcApiStyleMetadata);
   }
 
   /**

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -612,14 +612,14 @@ ${e.message}`);
   }
 
   /**
-   * Returns a promise resolving to a document describing the style metadata.
+   * Returns a promise resolving to a document describing the style.
    * @param styleId The style identifier
    */
-  async getStyleMetadata(styleId: string): Promise<OgcApiStyleMetadata> {
+  async getStyle(styleId: string): Promise<OgcApiStyleMetadata> {
     const metadataDoc = await this.getStyleMetadataDocument(styleId);
     if (!metadataDoc) {
       throw new EndpointError(
-        `Could not get metadata: there is no relation of type "describedby" for style "${styleId}".`
+        `Could not get style metadata: there is no relation of type "describedby" for style "${styleId}".`
       );
     }
     return parseBaseStyleMetadata(metadataDoc as OgcApiStyleMetadata);

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -278,12 +278,10 @@ ${e.message}`);
     const styleDoc = (styleData?.styles)?.find(
       (style) => style.id === styleId
     );
-    try {
-      return await fetchLink(styleDoc as OgcApiDocument, 'describedby', this.baseUrl);
-    } catch (error) {
-      throw new EndpointError(
-        `Could not get metadata: there is no relation of type "describedby" for style "${styleId}".`
-      );
+    if (hasLinks(styleDoc as OgcApiDocument, ['describedby'])){
+      return fetchLink(styleDoc as OgcApiDocument, 'describedby', this.baseUrl);
+    } else {
+      return null;
     }
   }
 
@@ -619,6 +617,11 @@ ${e.message}`);
    */
   async getStyleMetadata(styleId: string): Promise<OgcApiStyleMetadata> {
     const metadataDoc = await this.getStyleMetadataDocument(styleId);
+    if (!metadataDoc) {
+      throw new EndpointError(
+        `Could not get metadata: there is no relation of type "describedby" for style "${styleId}".`
+      );
+    }
     return parseBaseStyleMetadata(metadataDoc as OgcApiStyleMetadata);
   }
 
@@ -632,7 +635,7 @@ ${e.message}`);
     mimeType: string
   ): Promise<string> {
     const metadataDoc = await this.getStyleMetadataDocument(styleId);
-    const urlFromMetadata = (metadataDoc as OgcApiStyleMetadata).stylesheets.find(
+    const urlFromMetadata = (metadataDoc as OgcApiStyleMetadata)?.stylesheets?.find(
       s => s.link.type === mimeType && s.link.rel === 'stylesheet'
     )?.link?.href;
 

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -274,7 +274,9 @@ ${e.message}`);
     styleId: string,
     collectionId?: string
   ): Promise<OgcApiDocument> {
-    const doc = collectionId ? await this.getCollectionDocument(collectionId) : await this.root;
+    const doc = collectionId
+      ? await this.getCollectionDocument(collectionId)
+      : await this.root;
     const stylesLinkJson = getLinkUrl(
       doc as OgcApiDocument,
       ['styles', 'http://www.opengis.net/def/rel/ogc/1.0/styles'],
@@ -286,7 +288,9 @@ ${e.message}`);
       ['styles', 'http://www.opengis.net/def/rel/ogc/1.0/styles'],
       this.baseUrl
     );
-    const styleData = await fetchDocument(stylesLinkJson ?? stylesLink) as OgcApiStylesDocument;
+    const styleData = (await fetchDocument(
+      stylesLinkJson ?? stylesLink
+    )) as OgcApiStylesDocument;
 
     if (!styleData.styles.some((style) => style.id === styleId)) {
       throw new EndpointError(`Style not found: "${styleId}".`);
@@ -617,7 +621,9 @@ ${e.message}`);
    * @param collectionId - Optional unique identifier for the collection.
    */
   async allStyles(collectionId?: string): Promise<OgcStyleBrief[]> {
-    const doc = collectionId ? await this.getCollectionDocument(collectionId) : await this.root;
+    const doc = collectionId
+      ? await this.getCollectionDocument(collectionId)
+      : await this.root;
     const stylesLink = getLinkUrl(
       doc as OgcApiDocument,
       ['styles', 'http://www.opengis.net/def/rel/ogc/1.0/styles'],
@@ -628,7 +634,7 @@ ${e.message}`);
         'Could not get styles: there is no relation of type "styles"'
       );
     }
-    const styleData = await fetchDocument(stylesLink) as OgcApiStylesDocument;
+    const styleData = (await fetchDocument(stylesLink)) as OgcApiStylesDocument;
     return styleData.styles.map(parseBasicStyleInfo);
   }
 
@@ -638,8 +644,14 @@ ${e.message}`);
    * @param styleId - The style identifier
    * @param collectionId - Optional unique identifier for the collection.
    */
-  async getStyle(styleId: string, collectionId?: string): Promise<OgcStyleFull | OgcStyleBrief> {
-    const metadataDoc = await this.getStyleMetadataDocument(styleId, collectionId);
+  async getStyle(
+    styleId: string,
+    collectionId?: string
+  ): Promise<OgcStyleFull | OgcStyleBrief> {
+    const metadataDoc = await this.getStyleMetadataDocument(
+      styleId,
+      collectionId
+    );
     if (!metadataDoc?.stylesheets) {
       return parseBasicStyleInfo(metadataDoc as OgcApiStyleMetadata);
     }
@@ -652,8 +664,15 @@ ${e.message}`);
    * @param mimeType - Stylesheet MIME type
    * @param collectionId - Optional unique identifier for the collection.
    */
-  async getStylesheetUrl(styleId: string, mimeType: string, collectionId?: string): Promise<string> {
-    const stylesDoc = await this.getStyleMetadataDocument(styleId, collectionId);
+  async getStylesheetUrl(
+    styleId: string,
+    mimeType: string,
+    collectionId?: string
+  ): Promise<string> {
+    const stylesDoc = await this.getStyleMetadataDocument(
+      styleId,
+      collectionId
+    );
 
     if (stylesDoc.stylesheets) {
       const urlFromMetadata = (

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -109,6 +109,9 @@ export function checkStyleConformance(conformance: ConformanceClass[]) {
   return (
     conformance.indexOf(
       'http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/core'
+    ) > -1 ||
+    conformance.indexOf(
+      'http://www.opengis.net/spec/ogcapi-styles-1/1.0/conf/core'
     ) > -1
   );
 }

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -7,9 +7,9 @@ import {
   OgcApiDocument,
   OgcApiEndpointInfo,
   OgcApiStyleMetadata,
-  OgcApiStyleMetadataInfo,
   OgcApiStylesDocument,
-  StyleItem,
+  OgcStyleBrief,
+  OgcStyleFull,
   TileMatrixSet,
 } from './model.js';
 import { assertHasLinks } from './link-utils.js';
@@ -225,17 +225,16 @@ export function parseTileMatrixSets(doc: OgcApiDocument): TileMatrixSet[] {
   return [];
 }
 
-export function parseBasicStyleInfo(doc: OgcApiStyleMetadata): StyleItem {
-  const { stylesheets, id, title } = doc;
-  const stylesheetFormats = stylesheets
-    .filter((stylesheet) => stylesheet.link.rel === 'stylesheet')
-    .map((stylesheet) => stylesheet.link.type);
-
+export function parseBasicStyleInfo(doc: OgcApiStyleMetadata): OgcStyleBrief {
+  const formats = doc.links
+    .filter((link) => link.rel === 'stylesheet')
+    .map((link) => link.type)
+    .filter((type) => type !== 'text/html');
   return {
-    id,
-    title,
-    formats: stylesheetFormats,
-  } as StyleItem;
+    formats,
+    id: doc.id,
+    ...doc.title && {title: doc.title},
+  };
 }
 
 export function parseStylesAsList(): (doc: OgcApiStylesDocument) => string[] {
@@ -245,15 +244,15 @@ export function parseStylesAsList(): (doc: OgcApiStylesDocument) => string[] {
 
 export function parseFullStyleInfo(
   doc: OgcApiStyleMetadata
-): OgcApiStyleMetadata {
+): OgcStyleFull {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { stylesheets, links, ...props } = doc;
   const stylesheetFormats = stylesheets
-    .filter((stylesheet) => stylesheet.link.rel === 'stylesheet')
-    .map((stylesheet) => stylesheet.link.type);
+    ?.filter((stylesheet) => stylesheet.link.rel === 'stylesheet')
+    ?.map((stylesheet) => stylesheet.link.type);
   return {
-    stylesheetFormats,
-    stylesheets,
+    ...stylesheetFormats && {stylesheetFormats},
+    ...stylesheets && {stylesheets},
     ...props,
-  } as OgcApiStyleMetadataInfo;
+  } as OgcStyleFull;
 }

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -234,7 +234,7 @@ export function parseStyleMetadataAsList(doc: OgcApiStyleMetadata): StyleItem {
   return {
     id,
     title,
-    formats: stylesheetFormats
+    formats: stylesheetFormats,
   } as StyleItem;
 }
 

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -225,7 +225,7 @@ export function parseTileMatrixSets(doc: OgcApiDocument): TileMatrixSet[] {
   return [];
 }
 
-export function parseStyleMetadataAsList(doc: OgcApiStyleMetadata): StyleItem {
+export function parseBasicStyleInfo(doc: OgcApiStyleMetadata): StyleItem {
   const { stylesheets, id, title } = doc;
   const stylesheetFormats = stylesheets
     .filter((stylesheet) => stylesheet.link.rel === 'stylesheet')
@@ -243,7 +243,7 @@ export function parseStylesAsList(): (doc: OgcApiStylesDocument) => string[] {
     doc?.styles?.map((style) => style.id as string);
 }
 
-export function parseStyleMetadata(
+export function parseFullStyleInfo(
   doc: OgcApiStyleMetadata
 ): OgcApiStyleMetadata {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -225,18 +225,17 @@ export function parseTileMatrixSets(doc: OgcApiDocument): TileMatrixSet[] {
   return [];
 }
 
-export function parseStyles(): (doc: OgcApiStylesDocument) => StyleItem[] {
-  return (doc: OgcApiStylesDocument) =>
-    doc?.styles?.map((style) => {
-      const formats = style.links
-        .filter((link) => link.rel === 'stylesheet')
-        .map((link) => link.type);
-      return {
-        formats,
-        id: style.id,
-        title: style.title,
-      };
-    });
+export function parseStyleMetadataAsList(doc: OgcApiStyleMetadata): StyleItem {
+  const { stylesheets, id, title } = doc;
+  const stylesheetFormats = stylesheets
+    .filter((stylesheet) => stylesheet.link.rel === 'stylesheet')
+    .map((stylesheet) => stylesheet.link.type);
+
+  return {
+    id,
+    title,
+    formats: stylesheetFormats
+  } as StyleItem;
 }
 
 export function parseStylesAsList(): (doc: OgcApiStylesDocument) => string[] {
@@ -244,7 +243,7 @@ export function parseStylesAsList(): (doc: OgcApiStylesDocument) => string[] {
     doc?.styles?.map((style) => style.id as string);
 }
 
-export function parseBaseStyleMetadata(
+export function parseStyleMetadata(
   doc: OgcApiStyleMetadata
 ): OgcApiStyleMetadata {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -6,6 +6,10 @@ import {
   OgcApiCollectionInfo,
   OgcApiDocument,
   OgcApiEndpointInfo,
+  OgcApiStyleMetadata,
+  OgcApiStyleMetadataInfo,
+  OgcApiStylesDocument,
+  StyleItem,
   TileMatrixSet,
 } from './model.js';
 import { assertHasLinks } from './link-utils.js';
@@ -216,4 +220,39 @@ export function parseTileMatrixSets(doc: OgcApiDocument): TileMatrixSet[] {
     });
   }
   return [];
+}
+
+export function parseStyles(): (doc: OgcApiStylesDocument) => StyleItem[] {
+  return (doc: OgcApiStylesDocument) =>
+    (doc?.styles)
+      ?.map((style) => {
+        const formats = style.links
+          .filter((link) => link.rel === 'stylesheet')
+          .map((link) => link.type);
+        return {
+          formats,
+          id: style.id,
+          title: style.title
+        };
+      });
+}
+
+export function parseStylesAsList(): (doc: OgcApiStylesDocument) => string[] {
+  return (doc: OgcApiStylesDocument) =>
+    (doc?.styles)
+      ?.map((style) => style.id as string);
+}
+
+export function parseBaseStyleMetadata(
+  doc: OgcApiStyleMetadata
+): OgcApiStyleMetadata {
+  const { stylesheets, ...props } = doc;
+  const stylesheetFormats = stylesheets
+    .filter((stylesheet) => stylesheet.link.rel === 'stylesheet')
+    .map((stylesheet) => stylesheet.link.type);
+  return { 
+    stylesheetFormats,
+    stylesheets,
+    ...props
+  } as OgcApiStyleMetadataInfo;
 }

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -247,7 +247,8 @@ export function parseStylesAsList(): (doc: OgcApiStylesDocument) => string[] {
 export function parseBaseStyleMetadata(
   doc: OgcApiStyleMetadata
 ): OgcApiStyleMetadata {
-  const { stylesheets, ...props } = doc;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { stylesheets, links, ...props } = doc;
   const stylesheetFormats = stylesheets
     .filter((stylesheet) => stylesheet.link.rel === 'stylesheet')
     .map((stylesheet) => stylesheet.link.type);

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -227,23 +227,21 @@ export function parseTileMatrixSets(doc: OgcApiDocument): TileMatrixSet[] {
 
 export function parseStyles(): (doc: OgcApiStylesDocument) => StyleItem[] {
   return (doc: OgcApiStylesDocument) =>
-    (doc?.styles)
-      ?.map((style) => {
-        const formats = style.links
-          .filter((link) => link.rel === 'stylesheet')
-          .map((link) => link.type);
-        return {
-          formats,
-          id: style.id,
-          title: style.title
-        };
-      });
+    doc?.styles?.map((style) => {
+      const formats = style.links
+        .filter((link) => link.rel === 'stylesheet')
+        .map((link) => link.type);
+      return {
+        formats,
+        id: style.id,
+        title: style.title,
+      };
+    });
 }
 
 export function parseStylesAsList(): (doc: OgcApiStylesDocument) => string[] {
   return (doc: OgcApiStylesDocument) =>
-    (doc?.styles)
-      ?.map((style) => style.id as string);
+    doc?.styles?.map((style) => style.id as string);
 }
 
 export function parseBaseStyleMetadata(
@@ -253,9 +251,9 @@ export function parseBaseStyleMetadata(
   const stylesheetFormats = stylesheets
     .filter((stylesheet) => stylesheet.link.rel === 'stylesheet')
     .map((stylesheet) => stylesheet.link.type);
-  return { 
+  return {
     stylesheetFormats,
     stylesheets,
-    ...props
+    ...props,
   } as OgcApiStyleMetadataInfo;
 }

--- a/src/ogc-api/info.ts
+++ b/src/ogc-api/info.ts
@@ -233,7 +233,7 @@ export function parseBasicStyleInfo(doc: OgcApiStyleMetadata): OgcStyleBrief {
   return {
     formats,
     id: doc.id,
-    ...doc.title && {title: doc.title},
+    ...(doc.title && { title: doc.title }),
   };
 }
 
@@ -242,17 +242,15 @@ export function parseStylesAsList(): (doc: OgcApiStylesDocument) => string[] {
     doc?.styles?.map((style) => style.id as string);
 }
 
-export function parseFullStyleInfo(
-  doc: OgcApiStyleMetadata
-): OgcStyleFull {
+export function parseFullStyleInfo(doc: OgcApiStyleMetadata): OgcStyleFull {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { stylesheets, links, ...props } = doc;
   const stylesheetFormats = stylesheets
     ?.filter((stylesheet) => stylesheet.link.rel === 'stylesheet')
     ?.map((stylesheet) => stylesheet.link.type);
   return {
-    ...stylesheetFormats && {stylesheetFormats},
-    ...stylesheets && {stylesheets},
+    ...(stylesheetFormats && { stylesheetFormats }),
+    ...(stylesheets && { stylesheets }),
     ...props,
   } as OgcStyleFull;
 }

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -79,23 +79,29 @@ export function fetchCollectionRoot(
 
 export function getLinks(
   doc: OgcApiDocument,
-  relType: string | string[]
+  relType: string | string[],
+  mimeType?: string
 ): OgcApiDocumentLink[] {
-  return (
+  const links = (
     doc.links?.filter((link) =>
       Array.isArray(relType)
         ? relType.indexOf(link.rel) > -1
         : link.rel === relType
     ) || []
   );
+  if (mimeType) {
+    return links.filter(link => link.type === mimeType);
+  }
+  return links;
 }
 
 export function getLinkUrl(
   doc: OgcApiDocument,
   relType: string | string[],
-  baseUrl?: string
+  baseUrl?: string,
+  mimeType?: string
 ): string | null {
-  const link = getLinks(doc, relType)[0];
+  const link = getLinks(doc, relType, mimeType)[0];
   if (!link) return null;
   return new URL(link.href, baseUrl || window.location.toString()).toString();
 }

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -82,15 +82,14 @@ export function getLinks(
   relType: string | string[],
   mimeType?: string
 ): OgcApiDocumentLink[] {
-  const links = (
+  const links =
     doc.links?.filter((link) =>
       Array.isArray(relType)
         ? relType.indexOf(link.rel) > -1
         : link.rel === relType
-    ) || []
-  );
+    ) || [];
   if (mimeType) {
-    return links.filter(link => link.type === mimeType);
+    return links.filter((link) => link.type === mimeType);
   }
   return links;
 }

--- a/src/ogc-api/model.ts
+++ b/src/ogc-api/model.ts
@@ -163,3 +163,55 @@ export interface TileMatrixSet {
   id: string;
   uri: string;
 }
+
+export type StyleItem = {
+  title: string;
+  id: string;
+  links?: OgcApiDocumentLink[];
+  formats?: string[];
+};
+
+export type OgcApiStylesDocument = {
+  styles: StyleItem[];
+  links: OgcApiDocumentLink[];
+};
+
+export type OgcApiStyleRecord = {
+  title: string;
+  id: string;
+};
+
+export type OgcApiStylesheet = {
+  link: OgcApiDocumentLink;
+  title?: string;
+  version?: string;
+  specification?: string;
+  native?: boolean;
+};
+
+export type OgcApiStyleMetadata = {
+  id: string;
+  title?: string;
+  description?: string;
+  keywords?: string[];
+  pointOfContact?: string;
+  license?: string;
+  created?: string;
+  updated?: string;
+  scope?: 'style';
+  version?: string;
+  stylesheets?: OgcApiStylesheet[];
+  layers?: {
+    id: string;
+    description?: string;
+    dataType?: 'vector' | 'map' | 'coverage' | 'model';
+    geometryType?: 'points' | 'lines' | 'polygons' | 'solids' | 'any';
+    propertiesSchema?: any; // https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v3.0/schema.json#/definitions/Schema
+    sampleData?: OgcApiDocumentLink;
+  }[];
+  links?: OgcApiDocumentLink[];
+};
+
+export type OgcApiStyleMetadataInfo = {
+  stylesheetFormats: string[];
+} & OgcApiStyleMetadata;

--- a/src/ogc-api/model.ts
+++ b/src/ogc-api/model.ts
@@ -171,6 +171,16 @@ export type StyleItem = {
   formats?: string[];
 };
 
+export type OgcStyleFull = {
+  stylesheetFormats: string[];
+} & OgcApiStyleMetadata;
+
+export type OgcStyleBrief = {
+  id: string;
+  title?: string;
+  formats?: string[];
+};
+
 export type OgcApiStylesDocument = {
   styles: StyleItem[];
   links: OgcApiDocumentLink[];
@@ -211,7 +221,3 @@ export type OgcApiStyleMetadata = {
   }[];
   links?: OgcApiDocumentLink[];
 };
-
-export type OgcApiStyleMetadataInfo = {
-  stylesheetFormats: string[];
-} & OgcApiStyleMetadata;


### PR DESCRIPTION
This attempts to add basic support for styles. For now just retrieving styles is supported.

Examples:

Get a list of available style identifiers:
```js
const endpoint = new OgcApiEndpoint('https://demo.ldproxy.net/zoomstack');
await endpoint.listAllStyles;
```

Get a list of styles (includes the supported formats, which you need for `getStylesheetUrl`):
```js
await endpoint.allStyles;
```

Get style metadata:
```js
await endpoint.getStyleMetadata('Deuteranopia');
```

Get stylesheet URL from metadata (or style document):
```js
await endpoint.getStylesheetUrl('Deuteranopia', 'application/vnd.esri.lyr');
```

Some questions / notes:

- not sure if the extra type `OgcApiStyleDocument` is needed - you could also use `OgcApiDocument` here if you add a `styles` subproperty. This would remove the need for casting sometimes
- `allStyles` currently gets all its information from the styles endpoint. There might be a link to a json representation for each style which contains more information. Maybe another function such as `getStyle({styleId})` is useful here?

For testing I mainly used the ldproxy demos at https://demo.ldproxy.net/ and https://test.cubewerx.com/cubewerx/cubeserv/demo/ogcapi

Happy for any suggestions or feedback!