### PR TITLE
[WFS] Add startIndex Support in URL generation and supportsStartIndex Method

### DIFF
--- a/src/wfs/endpoint.spec.ts
+++ b/src/wfs/endpoint.spec.ts
@@ -504,4 +504,11 @@ describe('WfsEndpoint', () => {
       );
     });
   });
+
+  describe('#supportsStartIndex', () => {
+    it('returns true if the WFS version is 2.0.0 or higher', async () => {
+      await endpoint.isReady();
+      expect(endpoint.supportsStartIndex()).toBeTruthy();
+    });
+  });
 });

--- a/src/wfs/endpoint.ts
+++ b/src/wfs/endpoint.ts
@@ -236,6 +236,14 @@ export default class WfsEndpoint {
   }
 
   /**
+   * Returns true if the WFS service supports the startIndex parameter.
+   */
+  supportsStartIndex(): boolean {
+    if (!this._version) return false;
+    return this._version >= '2.0.0';
+  }
+
+  /**
    * Returns a URL that can be used to query features from this feature type.
    * @param featureType
    * @param {Object} [options]

--- a/src/wfs/endpoint.ts
+++ b/src/wfs/endpoint.ts
@@ -253,6 +253,7 @@ export default class WfsEndpoint {
    * @property [options.outputCrs] if unspecified, this will be the data native projection
    * @property [options.extent] an extent to restrict returned objects
    * @property [options.extentCrs] if unspecified, `extent` should be in the data native projection
+   * @property [options.startIndex] if the service supports it, this will be the index of the first feature to return
    * @returns Returns null if endpoint is not ready
    */
   getFeatureUrl(
@@ -264,13 +265,21 @@ export default class WfsEndpoint {
       outputCrs?: CrsCode;
       extent?: BoundingBox;
       extentCrs?: CrsCode;
+      startIndex?: number;
     }
   ) {
     if (!this._featureTypes) {
       return null;
     }
-    const { maxFeatures, asJson, outputFormat, outputCrs, extent, extentCrs } =
-      options || {};
+    const {
+      maxFeatures,
+      asJson,
+      outputFormat,
+      outputCrs,
+      extent,
+      extentCrs,
+      startIndex,
+    } = options || {};
     const internalFeatureType = this._getFeatureTypeByName(featureType);
     if (!internalFeatureType) {
       throw new Error(
@@ -304,7 +313,8 @@ export default class WfsEndpoint {
       undefined,
       outputCrs,
       extent,
-      extentCrs
+      extentCrs,
+      startIndex
     );
   }
 }

--- a/src/wfs/url.spec.ts
+++ b/src/wfs/url.spec.ts
@@ -99,6 +99,25 @@ describe('WFS url helpers', () => {
         'http://example.com/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my%3Atype&SRSNAME=EPSG%3A2154&BBOX=10%2C20%2C100%2C200%2CEPSG%3A3857'
       );
     });
+    it('generates a correct URL (v2.0.0, startIndex set)', () => {
+      expect(
+        generateGetFeatureUrl(
+          'http://example.com/wfs',
+          '2.0.0',
+          'my:type',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          10
+        )
+      ).toBe(
+        'http://example.com/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my%3Atype&STARTINDEX=10'
+      );
+    });
   });
 
   describe('generateDescribeFeatureTypeUrl', () => {

--- a/src/wfs/url.ts
+++ b/src/wfs/url.ts
@@ -53,14 +53,8 @@ export function generateGetFeatureUrl(
     const extentJoined = extent.join(',');
     newParams.BBOX = extentCrs ? `${extentJoined},${extentCrs}` : extentJoined;
   }
-  if (startIndex !== undefined) {
-    if (version >= '2.0.0') {
-      newParams.STARTINDEX = startIndex.toString(10);
-    } else {
-      console.warn(
-        'The startIndex parameter is not supported for WFS version less than 2.0.0.'
-      );
-    }
+  if (startIndex) {
+    newParams.STARTINDEX = startIndex.toString(10);
   }
 
   return setQueryParams(serviceUrl, newParams);

--- a/src/wfs/url.ts
+++ b/src/wfs/url.ts
@@ -15,6 +15,7 @@ import { WfsVersion } from './model.js';
  * @param [outputCrs] if unspecified, this will be the data native projection
  * @param [extent] an extent to restrict returned objects
  * @param [extentCrs] if unspecified, `extent` should be in the data native projection
+ * @param [startIndex] if the service supports it, this will be the index of the first feature to return
  */
 export function generateGetFeatureUrl(
   serviceUrl: string,
@@ -26,7 +27,8 @@ export function generateGetFeatureUrl(
   hitsOnly?: boolean,
   outputCrs?: CrsCode,
   extent?: BoundingBox,
-  extentCrs?: CrsCode
+  extentCrs?: CrsCode,
+  startIndex?: number
 ) {
   const typeParam = version === '2.0.0' ? 'TYPENAMES' : 'TYPENAME';
   const countParam = version === '2.0.0' ? 'COUNT' : 'MAXFEATURES';
@@ -50,6 +52,15 @@ export function generateGetFeatureUrl(
   if (extent) {
     const extentJoined = extent.join(',');
     newParams.BBOX = extentCrs ? `${extentJoined},${extentCrs}` : extentJoined;
+  }
+  if (startIndex !== undefined) {
+    if (version >= '2.0.0') {
+      newParams.STARTINDEX = startIndex.toString(10);
+    } else {
+      console.warn(
+        'The startIndex parameter is not supported for WFS version less than 2.0.0.'
+      );
+    }
   }
 
   return setQueryParams(serviceUrl, newParams);


### PR DESCRIPTION
This PR includes the following updates:

- Introduces the support for `startIndex` in the `getFeatureUrl` and `generateGetFeatureUrl` functions
- Adds a `supportsStartIndex` method in the `WfsEndpoint` class.
