### PR TITLE
OGC API: Avoid "stream already consumed" errors on shared fetch calls

### DIFF
--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -43,6 +43,9 @@ beforeAll(() => {
     return {
       ok: true,
       headers: new Headers(),
+      clone: function () {
+        return this;
+      },
       json: () =>
         new Promise((resolve) => {
           resolve(JSON.parse(contents));
@@ -1633,7 +1636,8 @@ describe('OgcApiEndpoint', () => {
         await expect(endpoint.info).rejects.toEqual(
           new EndpointError(
             `The endpoint appears non-conforming, the following error was encountered:
-The document at http://local/sample-data/notjson?f=json does not appear to be valid JSON.`
+The document at http://local/sample-data/notjson?f=json does not appear to be valid JSON. Error was: Unexpected token 'h', "hello world
+" is not valid JSON`
           )
         );
       });

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -11,11 +11,14 @@ export function fetchDocument<T extends OgcApiDocument>(
     if (!resp.ok) {
       throw new Error(`The document at ${urlObj} could not be fetched.`);
     }
-    return resp.json().catch(() => {
-      throw new Error(
-        `The document at ${urlObj} does not appear to be valid JSON.`
-      );
-    }) as Promise<T>;
+    return resp
+      .clone()
+      .json()
+      .catch((e) => {
+        throw new Error(
+          `The document at ${urlObj} does not appear to be valid JSON. Error was: ${e.message}`
+        );
+      }) as Promise<T>;
   });
 }
 

--- a/src/shared/http-utils.spec.ts
+++ b/src/shared/http-utils.spec.ts
@@ -34,7 +34,7 @@ describe('HTTP utils', () => {
     beforeAll(() => {
       fetchBehaviour = 'ok';
       originalFetch = global.fetch; // keep reference of native impl
-      global.fetch = jest.fn((xmlString, opts) => {
+      global.fetch = jest.fn().mockImplementation((xmlString, opts) => {
         const noCors = opts && opts.mode === 'no-cors';
         const headers = { get: () => null };
         switch (fetchBehaviour) {
@@ -45,12 +45,18 @@ describe('HTTP utils', () => {
               status: 200,
               ok: true,
               headers,
+              clone: function () {
+                return this;
+              },
             });
           case 'httpError':
             return Promise.resolve({
               text: () => Promise.resolve('<error>Random error</error>'),
               status: 401,
               ok: false,
+              clone: function () {
+                return this;
+              },
             });
           case 'corsError':
             if (noCors)
@@ -71,6 +77,9 @@ describe('HTTP utils', () => {
                     headers,
                     arrayBuffer: () =>
                       Promise.resolve(Buffer.from(sampleXml, 'utf-8')),
+                    clone: function () {
+                      return this;
+                    },
                   }),
                 10
               );


### PR DESCRIPTION
When sharing fetch calls, the resulting data stream can only be consumed once. Now it is cloned before being consumed.