### PR TITLE
Add keywords to WMS and WFS

### DIFF
--- a/app/src/components/wfs/WfsFeatureTypeInfo.vue
+++ b/app/src/components/wfs/WfsFeatureTypeInfo.vue
@@ -55,7 +55,7 @@ export default {
           'geometry type': this.featureType.geometryType,
         }),
         ...('keywords' in this.featureType && {
-          'keywords': this.featureType.keywords,
+          keywords: this.featureType.keywords,
         }),
       };
     },

--- a/app/src/components/wfs/WfsFeatureTypeInfo.vue
+++ b/app/src/components/wfs/WfsFeatureTypeInfo.vue
@@ -54,6 +54,9 @@ export default {
         ...('geometryType' in this.featureType && {
           'geometry type': this.featureType.geometryType,
         }),
+        ...('keywords' in this.featureType && {
+          'keywords': this.featureType.keywords,
+        }),
       };
     },
     featureProperties() {

--- a/app/src/components/wms/WmsLayerInfo.vue
+++ b/app/src/components/wms/WmsLayerInfo.vue
@@ -64,7 +64,7 @@ export default {
           this.layer.attribution.title && {
             attribution: this.layer.attribution.title,
           }),
-          ...(this.layer.keywords && {keywords: this.layer.keywords})
+        ...(this.layer.keywords && { keywords: this.layer.keywords }),
       };
     },
     fullMapSrc() {

--- a/app/src/components/wms/WmsLayerInfo.vue
+++ b/app/src/components/wms/WmsLayerInfo.vue
@@ -64,6 +64,7 @@ export default {
           this.layer.attribution.title && {
             attribution: this.layer.attribution.title,
           }),
+          ...(this.layer.keywords && {keywords: this.layer.keywords})
       };
     },
     fullMapSrc() {

--- a/fixtures/wms/capabilities-brgm-1-1-1.xml
+++ b/fixtures/wms/capabilities-brgm-1-1-1.xml
@@ -139,6 +139,9 @@
                 <Keyword>BRGM</Keyword>
                 <Keyword>INSPIRE:ViewService</Keyword>
                 <Keyword>infoMapAccessService</Keyword>
+                <Keyword>WMS 1.1.1</Keyword>
+                <Keyword>WMS 1.3.0</Keyword>
+                <Keyword>SLD 1.1.0</Keyword>
             </KeywordList>
             <SRS>EPSG:4326</SRS>
             <SRS>CRS:84</SRS>
@@ -187,6 +190,7 @@
                     <KeywordList>
                         <Keyword>Geologie</Keyword>
                         <Keyword>INSPIRE:Geology</Keyword>
+                        <Keyword>Geology</Keyword>
                     </KeywordList>
                     <SRS>EPSG:4326</SRS>
                     <SRS>EPSG:3857</SRS>
@@ -243,6 +247,7 @@
                     <KeywordList>
                         <Keyword>Geologie</Keyword>
                         <Keyword>INSPIRE:Geology</Keyword>
+                        <Keyword>Geology</Keyword>
                     </KeywordList>
                     <SRS>EPSG:4326</SRS>
                     <SRS>EPSG:3857</SRS>
@@ -277,6 +282,7 @@
                     <KeywordList>
                         <Keyword>Geologie</Keyword>
                         <Keyword>INSPIRE:Geology</Keyword>
+                        <Keyword>Geology</Keyword>
                     </KeywordList>
                     <SRS>EPSG:4326</SRS>
                     <SRS>EPSG:3857</SRS>

--- a/src/wfs/capabilities.spec.ts
+++ b/src/wfs/capabilities.spec.ts
@@ -35,6 +35,10 @@ describe('WFS capabilities', () => {
         abstract:
           'Registre Parcellaire Graphique 2010 en Aquitaine - Agence de Service et de Paiement',
         defaultCrs: 'EPSG:2154',
+        keywords: [
+          "features",
+          "rpg2010",
+        ],
         latLonBoundingBox: [
           -1.9540704007796161, 42.73286181824404, 1.496463327812538,
           45.717071228823876,
@@ -53,6 +57,10 @@ describe('WFS capabilities', () => {
         abstract:
           'Représentation des moyennes journalières des trafics routiers sur les routes départementales de la\n                Charente (16) au 1er Janvier 2021.\n\n                Mise à jour : Mars 2021\n            ',
         defaultCrs: 'EPSG:2154',
+        keywords: [
+          "features",
+          "comptages_routiers_l",
+        ],
         latLonBoundingBox: [
           -0.4906009184568518, 45.175543885638376, 0.9778719979726385,
           46.14349349624617,
@@ -72,6 +80,10 @@ describe('WFS capabilities', () => {
         abstract:
           'Hiérarchisation du réseau routier départemental en fonction des caractéristiques de chaque section\n                de route et de son usage au 1er Janvier 2021.\n\n                Mise à jour : Mars 2021\n            ',
         defaultCrs: 'EPSG:2154',
+        keywords: [
+          "features",
+          "hierarchisation_l",
+        ],
         latLonBoundingBox: [
           -0.4832134559131876, 45.18037755571674, 0.9725372441782966,
           46.13877580094452,
@@ -131,6 +143,11 @@ describe('WFS capabilities', () => {
         expect(featureTypes[0]).toEqual({
           abstract: 'Domaine public',
           defaultCrs: 'EPSG:2154',
+          keywords: [
+            "domaine_public_hdf_com",
+            "domaine",
+            "public"
+          ],
           latLonBoundingBox: [
             1.3472171890368316, 48.82764887581316, 4.285589467078578,
             51.0896786738123,

--- a/src/wfs/capabilities.spec.ts
+++ b/src/wfs/capabilities.spec.ts
@@ -35,10 +35,7 @@ describe('WFS capabilities', () => {
         abstract:
           'Registre Parcellaire Graphique 2010 en Aquitaine - Agence de Service et de Paiement',
         defaultCrs: 'EPSG:2154',
-        keywords: [
-          "features",
-          "rpg2010",
-        ],
+        keywords: ['features', 'rpg2010'],
         latLonBoundingBox: [
           -1.9540704007796161, 42.73286181824404, 1.496463327812538,
           45.717071228823876,
@@ -57,10 +54,7 @@ describe('WFS capabilities', () => {
         abstract:
           'Représentation des moyennes journalières des trafics routiers sur les routes départementales de la\n                Charente (16) au 1er Janvier 2021.\n\n                Mise à jour : Mars 2021\n            ',
         defaultCrs: 'EPSG:2154',
-        keywords: [
-          "features",
-          "comptages_routiers_l",
-        ],
+        keywords: ['features', 'comptages_routiers_l'],
         latLonBoundingBox: [
           -0.4906009184568518, 45.175543885638376, 0.9778719979726385,
           46.14349349624617,
@@ -80,10 +74,7 @@ describe('WFS capabilities', () => {
         abstract:
           'Hiérarchisation du réseau routier départemental en fonction des caractéristiques de chaque section\n                de route et de son usage au 1er Janvier 2021.\n\n                Mise à jour : Mars 2021\n            ',
         defaultCrs: 'EPSG:2154',
-        keywords: [
-          "features",
-          "hierarchisation_l",
-        ],
+        keywords: ['features', 'hierarchisation_l'],
         latLonBoundingBox: [
           -0.4832134559131876, 45.18037755571674, 0.9725372441782966,
           46.13877580094452,
@@ -143,11 +134,7 @@ describe('WFS capabilities', () => {
         expect(featureTypes[0]).toEqual({
           abstract: 'Domaine public',
           defaultCrs: 'EPSG:2154',
-          keywords: [
-            "domaine_public_hdf_com",
-            "domaine",
-            "public"
-          ],
+          keywords: ['domaine_public_hdf_com', 'domaine', 'public'],
           latLonBoundingBox: [
             1.3472171890368316, 48.82764887581316, 4.285589467078578,
             51.0896786738123,

--- a/src/wfs/capabilities.ts
+++ b/src/wfs/capabilities.ts
@@ -158,6 +158,12 @@ function parseFeatureType(
         'Format'
       ).map(getElementText);
 
+  const keywords = findChildrenElement(
+    findChildElement(featureTypeEl, 'Keywords'),
+    'Keyword'
+  )
+    .map(getElementText)
+    .filter((v, i, arr) => arr.indexOf(v) === i);    
   return {
     name: getElementText(findChildElement(featureTypeEl, 'Name')),
     title: getElementText(findChildElement(featureTypeEl, 'Title')),
@@ -171,5 +177,6 @@ function parseFeatureType(
     latLonBoundingBox: serviceVersion.startsWith('1.0')
       ? parseBBox100()
       : parseBBox(),
+    keywords: keywords
   };
 }

--- a/src/wfs/capabilities.ts
+++ b/src/wfs/capabilities.ts
@@ -158,7 +158,12 @@ function parseFeatureType(
         'Format'
       ).map(getElementText);
 
-  const keywords = findChildrenElement(
+  const keywords = serviceVersion.startsWith('1.0')
+  ? getElementText(
+    findChildElement(featureTypeEl, 'Keywords'))
+      .split(',')
+      .map(keyword => keyword.trim())
+  : findChildrenElement(
     findChildElement(featureTypeEl, 'Keywords'),
     'Keyword'
   )

--- a/src/wfs/capabilities.ts
+++ b/src/wfs/capabilities.ts
@@ -159,16 +159,15 @@ function parseFeatureType(
       ).map(getElementText);
 
   const keywords = serviceVersion.startsWith('1.0')
-  ? getElementText(
-    findChildElement(featureTypeEl, 'Keywords'))
-      .split(',')
-      .map(keyword => keyword.trim())
-  : findChildrenElement(
-    findChildElement(featureTypeEl, 'Keywords'),
-    'Keyword'
-  )
-    .map(getElementText)
-    .filter((v, i, arr) => arr.indexOf(v) === i);    
+    ? getElementText(findChildElement(featureTypeEl, 'Keywords'))
+        .split(',')
+        .map((keyword) => keyword.trim())
+    : findChildrenElement(
+        findChildElement(featureTypeEl, 'Keywords'),
+        'Keyword'
+      )
+        .map(getElementText)
+        .filter((v, i, arr) => arr.indexOf(v) === i);
   return {
     name: getElementText(findChildElement(featureTypeEl, 'Name')),
     title: getElementText(findChildElement(featureTypeEl, 'Title')),
@@ -182,6 +181,6 @@ function parseFeatureType(
     latLonBoundingBox: serviceVersion.startsWith('1.0')
       ? parseBBox100()
       : parseBBox(),
-    keywords: keywords
+    keywords: keywords,
   };
 }

--- a/src/wfs/endpoint.spec.ts
+++ b/src/wfs/endpoint.spec.ts
@@ -131,10 +131,7 @@ describe('WfsEndpoint', () => {
           46.13877580094452,
         ],
         defaultCrs: 'EPSG:2154',
-        "keywords": [
-          "features",
-          "hierarchisation_l",
-        ],
+        keywords: ['features', 'hierarchisation_l'],
         otherCrs: ['EPSG:32615', 'EPSG:32616', 'EPSG:32617', 'EPSG:32618'],
         outputFormats: [
           'application/gml+xml; version=3.2',
@@ -174,10 +171,7 @@ describe('WfsEndpoint', () => {
           46.13877580094452,
         ],
         defaultCrs: 'EPSG:2154',
-        "keywords": [
-          "features",
-          "hierarchisation_l",
-        ],
+        keywords: ['features', 'hierarchisation_l'],
         otherCrs: ['EPSG:32615', 'EPSG:32616', 'EPSG:32617', 'EPSG:32618'],
         outputFormats: [
           'application/gml+xml; version=3.2',

--- a/src/wfs/endpoint.spec.ts
+++ b/src/wfs/endpoint.spec.ts
@@ -131,6 +131,10 @@ describe('WfsEndpoint', () => {
           46.13877580094452,
         ],
         defaultCrs: 'EPSG:2154',
+        "keywords": [
+          "features",
+          "hierarchisation_l",
+        ],
         otherCrs: ['EPSG:32615', 'EPSG:32616', 'EPSG:32617', 'EPSG:32618'],
         outputFormats: [
           'application/gml+xml; version=3.2',
@@ -170,6 +174,10 @@ describe('WfsEndpoint', () => {
           46.13877580094452,
         ],
         defaultCrs: 'EPSG:2154',
+        "keywords": [
+          "features",
+          "hierarchisation_l",
+        ],
         otherCrs: ['EPSG:32615', 'EPSG:32616', 'EPSG:32617', 'EPSG:32618'],
         outputFormats: [
           'application/gml+xml; version=3.2',

--- a/src/wfs/endpoint.ts
+++ b/src/wfs/endpoint.ts
@@ -124,6 +124,7 @@ export default class WfsEndpoint {
       defaultCrs: featureType.defaultCrs,
       otherCrs: featureType.otherCrs,
       outputFormats: featureType.outputFormats,
+      keywords: featureType.keywords
     } as WfsFeatureTypeSummary;
   }
 

--- a/src/wfs/endpoint.ts
+++ b/src/wfs/endpoint.ts
@@ -124,7 +124,7 @@ export default class WfsEndpoint {
       defaultCrs: featureType.defaultCrs,
       otherCrs: featureType.otherCrs,
       outputFormats: featureType.outputFormats,
-      keywords: featureType.keywords
+      keywords: featureType.keywords,
     } as WfsFeatureTypeSummary;
   }
 

--- a/src/wfs/featuretypeinfo.ts
+++ b/src/wfs/featuretypeinfo.ts
@@ -30,7 +30,7 @@ export function parseFeatureTypeInfo(
     otherCrs,
     outputFormats,
     latLonBoundingBox: boundingBox,
-    keywords
+    keywords,
   } = featureType;
 
   const hitsAttr = serviceVersion.startsWith('2.0')
@@ -78,7 +78,7 @@ export function parseFeatureTypeInfo(
     ...(geometryName && { geometryName }),
     ...(geometryType && { geometryType }),
     ...(!Number.isNaN(objectCount) && { objectCount }),
-    ...(keywords && {keywords})
+    ...(keywords && { keywords }),
   };
 }
 

--- a/src/wfs/featuretypeinfo.ts
+++ b/src/wfs/featuretypeinfo.ts
@@ -30,6 +30,7 @@ export function parseFeatureTypeInfo(
     otherCrs,
     outputFormats,
     latLonBoundingBox: boundingBox,
+    keywords
   } = featureType;
 
   const hitsAttr = serviceVersion.startsWith('2.0')
@@ -77,6 +78,7 @@ export function parseFeatureTypeInfo(
     ...(geometryName && { geometryName }),
     ...(geometryType && { geometryType }),
     ...(!Number.isNaN(objectCount) && { objectCount }),
+    ...(keywords && {keywords})
   };
 }
 

--- a/src/wfs/model.ts
+++ b/src/wfs/model.ts
@@ -10,6 +10,7 @@ export type WfsFeatureTypeInternal = {
   otherCrs: CrsCode[];
   outputFormats: MimeType[];
   latLonBoundingBox?: BoundingBox;
+  keywords?: string[];
 };
 
 export type FeaturePropertyType = string | number | boolean;
@@ -44,6 +45,7 @@ export type WfsFeatureTypeSummary = {
   defaultCrs: CrsCode;
   otherCrs: CrsCode[];
   outputFormats: MimeType[];
+  keywords?: string[];
 };
 
 export type WfsFeatureTypeFull = {
@@ -73,6 +75,7 @@ export type WfsFeatureTypeFull = {
    * Not defined if object count could not be determined
    */
   objectCount?: number;
+  keywords?: string[];
 };
 
 export type WfsFeatureWithProps = {

--- a/src/wms/capabilities.spec.ts
+++ b/src/wms/capabilities.spec.ts
@@ -53,6 +53,15 @@ describe('WMS capabilities', () => {
           'EPSG:4171': ['-180', '-90', '180', '90'],
           'EPSG:4326': ['-180', '-90', '180', '90'],
         },
+        keywords: [
+          "Géologie",
+          "BRGM",
+          "INSPIRE:ViewService",
+          "infoMapAccessService",
+          "WMS 1.1.1",
+          "WMS 1.3.0",
+          "SLD 1.1.0",
+         ],
         name: 'GEOSERVICES_GEOLOGIE',
         styles: [
           {
@@ -76,6 +85,7 @@ describe('WMS capabilities', () => {
               'EPSG:4171': ['-180', '-90', '180', '90'],
               'EPSG:4326': ['-180', '-90', '180', '90'],
             },
+            keywords: [],
             name: 'GEOLOGIE',
             styles,
             title: 'Cartes géologiques',
@@ -117,6 +127,11 @@ describe('WMS capabilities', () => {
                   ],
                   'EPSG:4326': ['-5.86764', '41.1701', '11.0789', '51.1419'],
                 },
+                "keywords": [
+                  "Geologie",
+                  "INSPIRE:Geology",
+                  "Geology",
+                ],
                 name: 'SCAN_F_GEOL1M',
                 styles: [
                   {
@@ -167,6 +182,11 @@ describe('WMS capabilities', () => {
                   ],
                   'EPSG:4326': ['-6.20495', '41.9671', '12.2874', '51.2917'],
                 },
+                "keywords": [
+                  "Geologie",
+                  "INSPIRE:Geology",
+                  "Geology",
+                ],
                 name: 'SCAN_F_GEOL250',
                 styles,
                 title: 'Carte géologique image de la France au 1/250000',
@@ -204,6 +224,11 @@ describe('WMS capabilities', () => {
                   ],
                   'EPSG:4326': ['-12.2064', '40.681', '11.894', '52.1672'],
                 },
+                "keywords": [
+                  "Geologie",
+                  "INSPIRE:Geology",
+                  "Geology",
+                ],
                 name: 'SCAN_D_GEOL50',
                 styles,
                 title: 'Carte géologique image de la France au 1/50 000e',
@@ -229,6 +254,7 @@ describe('WMS capabilities', () => {
                   'EPSG:4171': ['-180', '-90', '180', '90'],
                   'EPSG:4326': ['-180', '-90', '180', '90'],
                 },
+                "keywords": [],
                 name: 'INHERIT_BBOX',
                 styles: [
                   {

--- a/src/wms/capabilities.spec.ts
+++ b/src/wms/capabilities.spec.ts
@@ -54,14 +54,14 @@ describe('WMS capabilities', () => {
           'EPSG:4326': ['-180', '-90', '180', '90'],
         },
         keywords: [
-          "Géologie",
-          "BRGM",
-          "INSPIRE:ViewService",
-          "infoMapAccessService",
-          "WMS 1.1.1",
-          "WMS 1.3.0",
-          "SLD 1.1.0",
-         ],
+          'Géologie',
+          'BRGM',
+          'INSPIRE:ViewService',
+          'infoMapAccessService',
+          'WMS 1.1.1',
+          'WMS 1.3.0',
+          'SLD 1.1.0',
+        ],
         name: 'GEOSERVICES_GEOLOGIE',
         styles: [
           {
@@ -127,11 +127,7 @@ describe('WMS capabilities', () => {
                   ],
                   'EPSG:4326': ['-5.86764', '41.1701', '11.0789', '51.1419'],
                 },
-                "keywords": [
-                  "Geologie",
-                  "INSPIRE:Geology",
-                  "Geology",
-                ],
+                keywords: ['Geologie', 'INSPIRE:Geology', 'Geology'],
                 name: 'SCAN_F_GEOL1M',
                 styles: [
                   {
@@ -182,11 +178,7 @@ describe('WMS capabilities', () => {
                   ],
                   'EPSG:4326': ['-6.20495', '41.9671', '12.2874', '51.2917'],
                 },
-                "keywords": [
-                  "Geologie",
-                  "INSPIRE:Geology",
-                  "Geology",
-                ],
+                keywords: ['Geologie', 'INSPIRE:Geology', 'Geology'],
                 name: 'SCAN_F_GEOL250',
                 styles,
                 title: 'Carte géologique image de la France au 1/250000',
@@ -224,11 +216,7 @@ describe('WMS capabilities', () => {
                   ],
                   'EPSG:4326': ['-12.2064', '40.681', '11.894', '52.1672'],
                 },
-                "keywords": [
-                  "Geologie",
-                  "INSPIRE:Geology",
-                  "Geology",
-                ],
+                keywords: ['Geologie', 'INSPIRE:Geology', 'Geology'],
                 name: 'SCAN_D_GEOL50',
                 styles,
                 title: 'Carte géologique image de la France au 1/50 000e',
@@ -254,7 +242,7 @@ describe('WMS capabilities', () => {
                   'EPSG:4171': ['-180', '-90', '180', '90'],
                   'EPSG:4326': ['-180', '-90', '180', '90'],
                 },
-                "keywords": [],
+                keywords: [],
                 name: 'INHERIT_BBOX',
                 styles: [
                   {

--- a/src/wms/capabilities.ts
+++ b/src/wms/capabilities.ts
@@ -134,11 +134,11 @@ function parseLayer(
       : inheritedBoundingBoxes;
 
   const keywords = findChildrenElement(
-      findChildElement(layerEl, 'KeywordList'),
-      'Keyword'
-    )
-      .map(getElementText)
-      .filter((v, i, arr) => arr.indexOf(v) === i);
+    findChildElement(layerEl, 'KeywordList'),
+    'Keyword'
+  )
+    .map(getElementText)
+    .filter((v, i, arr) => arr.indexOf(v) === i);
 
   const children = findChildrenElement(layerEl, 'Layer').map((layer) =>
     parseLayer(layer, version, availableCrs, styles, attribution, boundingBoxes)

--- a/src/wms/capabilities.ts
+++ b/src/wms/capabilities.ts
@@ -132,6 +132,14 @@ function parseLayer(
     Object.keys(boundingBoxes).length > 0 || inheritedBoundingBoxes === null
       ? boundingBoxes
       : inheritedBoundingBoxes;
+
+  const keywords = findChildrenElement(
+      findChildElement(layerEl, 'KeywordList'),
+      'Keyword'
+    )
+      .map(getElementText)
+      .filter((v, i, arr) => arr.indexOf(v) === i);
+
   const children = findChildrenElement(layerEl, 'Layer').map((layer) =>
     parseLayer(layer, version, availableCrs, styles, attribution, boundingBoxes)
   );
@@ -143,6 +151,7 @@ function parseLayer(
     styles,
     attribution,
     boundingBoxes,
+    keywords,
     ...(children.length && { children }),
   };
 }

--- a/src/wms/endpoint.spec.ts
+++ b/src/wms/endpoint.spec.ts
@@ -131,6 +131,7 @@ describe('WmsEndpoint', () => {
           'EPSG:4171': ['-180', '-90', '180', '90'],
           'EPSG:4326': ['-180', '-90', '180', '90'],
         },
+        keywords: [],
         name: 'GEOLOGIE',
         styles: [
           {

--- a/src/wms/model.ts
+++ b/src/wms/model.ts
@@ -33,7 +33,7 @@ export type WmsLayerFull = {
    */
   boundingBoxes: Record<CrsCode, BoundingBox>;
   attribution?: WmsLayerAttribution;
-  keywords?: string[],
+  keywords?: string[];
   /**
    * Not defined if the layer is a leaf in the tree
    */

--- a/src/wms/model.ts
+++ b/src/wms/model.ts
@@ -33,6 +33,7 @@ export type WmsLayerFull = {
    */
   boundingBoxes: Record<CrsCode, BoundingBox>;
   attribution?: WmsLayerAttribution;
+  keywords?: string[],
   /**
    * Not defined if the layer is a leaf in the tree
    */


### PR DESCRIPTION
This PR adds keywords to the WMS and WFS layers/featuretypes output, in the same way that keywords are added to the top level capability documents.

One of the test fixtures (fixtures/wms/capabilities-brgm-1-1-1.xml) had to be modified to make them consistent between versions (keywords didn't appear in one version that did in another). I felt changing the fixture was safer but it could be changed to instead change the test to handle the differences.