### PR TITLE
Add 'queryable' property to WMS

### DIFF
--- a/app/src/components/wms/WmsLayerInfo.vue
+++ b/app/src/components/wms/WmsLayerInfo.vue
@@ -65,6 +65,7 @@ export default {
             attribution: this.layer.attribution.title,
           }),
         ...(this.layer.keywords && { keywords: this.layer.keywords }),
+        ...(this.layer.queryable && { queryable: this.layer.queryable }),
       };
     },
     fullMapSrc() {

--- a/src/wms/capabilities.spec.ts
+++ b/src/wms/capabilities.spec.ts
@@ -63,6 +63,7 @@ describe('WMS capabilities', () => {
           'SLD 1.1.0',
         ],
         name: 'GEOSERVICES_GEOLOGIE',
+        queryable: false,
         styles: [
           {
             legendUrl: expect.stringContaining(
@@ -87,6 +88,7 @@ describe('WMS capabilities', () => {
             },
             keywords: [],
             name: 'GEOLOGIE',
+            queryable: false,
             styles,
             title: 'Cartes géologiques',
             children: [
@@ -129,6 +131,7 @@ describe('WMS capabilities', () => {
                 },
                 keywords: ['Geologie', 'INSPIRE:Geology', 'Geology'],
                 name: 'SCAN_F_GEOL1M',
+                queryable: false,
                 styles: [
                   {
                     legendUrl:
@@ -180,6 +183,7 @@ describe('WMS capabilities', () => {
                 },
                 keywords: ['Geologie', 'INSPIRE:Geology', 'Geology'],
                 name: 'SCAN_F_GEOL250',
+                queryable: false,
                 styles,
                 title: 'Carte géologique image de la France au 1/250000',
               },
@@ -218,6 +222,7 @@ describe('WMS capabilities', () => {
                 },
                 keywords: ['Geologie', 'INSPIRE:Geology', 'Geology'],
                 name: 'SCAN_D_GEOL50',
+                queryable: false,
                 styles,
                 title: 'Carte géologique image de la France au 1/50 000e',
               },
@@ -244,6 +249,7 @@ describe('WMS capabilities', () => {
                 },
                 keywords: [],
                 name: 'INHERIT_BBOX',
+                queryable: false,
                 styles: [
                   {
                     name: 'default',

--- a/src/wms/capabilities.ts
+++ b/src/wms/capabilities.ts
@@ -133,6 +133,8 @@ function parseLayer(
       ? boundingBoxes
       : inheritedBoundingBoxes;
 
+  const queryable = layerEl.attributes.queryable === '1' ? true : false;
+
   const keywords = findChildrenElement(
     findChildElement(layerEl, 'KeywordList'),
     'Keyword'
@@ -152,6 +154,7 @@ function parseLayer(
     attribution,
     boundingBoxes,
     keywords,
+    queryable,
     ...(children.length && { children }),
   };
 }

--- a/src/wms/endpoint.spec.ts
+++ b/src/wms/endpoint.spec.ts
@@ -133,6 +133,7 @@ describe('WmsEndpoint', () => {
         },
         keywords: [],
         name: 'GEOLOGIE',
+        queryable: false,
         styles: [
           {
             name: 'default',

--- a/src/wms/model.ts
+++ b/src/wms/model.ts
@@ -32,6 +32,7 @@ export type WmsLayerFull = {
    * Dict of bounding boxes where keys are CRS codes
    */
   boundingBoxes: Record<CrsCode, BoundingBox>;
+  queryable: boolean;
   attribution?: WmsLayerAttribution;
   keywords?: string[];
   /**


### PR DESCRIPTION
This PR adds a boolean `queryable` property to the WMS model to indicate if a layer is queryable via GetFeatureInfo or not.

The `queryable` property is an optional attribute on the WMS Layer with either a '1' (is queryable) or '0' (not queryable). If the attribute doesn't exist it should be assumed it is not queryable.

### Possible Issues
- The WMS spec mentions that the `queryable` attribute can be inherited, but I have never seen a real world example where this occurs. This PR does not handle that possibility and will revert to a layer being not `queryable` if the attribute doesn't exist on the layer. This could be improved but I'm not sure how and whether its worth the effort at this point.
- The way the check works simply checks to see if a `queryable` attribute is equal to the string "1". I see no reason this shouldn't work in all cases, but better implementation ideas are welcome
- All the tests return false for `queryable`, there are no tests for a 'true'
- There are other attributes available on the layer (e.g. `opaque`) which I've ignored, as queryable is currently the only one I care about. 