### PR TITLE
Node bundle: make `node-fetch` an external dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.1.1-dev",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@rgrove/parse-xml": "^4.1.0"
+        "@rgrove/parse-xml": "^4.1.0",
+        "node-fetch": "^3.3.1"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.10",
@@ -27,7 +28,6 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "mitt": "^3.0.0",
-        "node-fetch": "^3.3.1",
         "ol": "^8.2.0",
         "prettier": "2.8.8",
         "proj4": "^2.10.0",
@@ -3667,7 +3667,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -4470,7 +4469,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4564,7 +4562,6 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -7237,7 +7234,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7256,7 +7252,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
       "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
-      "dev": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -9097,7 +9092,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -11981,8 +11975,7 @@
     "data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
     },
     "data-urls": {
       "version": "3.0.2",
@@ -12569,7 +12562,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -12635,7 +12627,6 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
       "requires": {
         "fetch-blob": "^3.1.2"
       }
@@ -14633,14 +14624,12 @@
     "node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
       "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
-      "dev": true,
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -15831,8 +15820,7 @@
     "web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "dev": true
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "web-worker": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   ],
   "type": "module",
   "dependencies": {
-    "@rgrove/parse-xml": "^4.1.0"
+    "@rgrove/parse-xml": "^4.1.0",
+    "node-fetch": "^3.3.1"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.10",
@@ -31,7 +32,6 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "mitt": "^3.0.0",
-    "node-fetch": "^3.3.1",
     "ol": "^8.2.0",
     "prettier": "2.8.8",
     "proj4": "^2.10.0",

--- a/vite.node-config.js
+++ b/vite.node-config.js
@@ -5,7 +5,7 @@ export default defineConfig({
   build: {
     ssr: true,
     rollupOptions: {
-      external: [/^ol/, 'proj4'],
+      external: [/^ol/, 'proj4', 'node-fetch'],
       input: 'src-node/index.ts',
       output: {
         entryFileNames: 'dist-node.js',


### PR DESCRIPTION
This makes the node bundle go from 280k to 240k; node-fetch is now a runtime dependency.

Should also fix issues with missing dependencies when using the node bundle (e.g. `data-buffer-to-uri`)