### PR TITLE
Keep d.ts files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A pure JS library for interacting with geospatial services.",
   "main": "./dist/dist-node.js",
   "browser": "./dist/index.js",
-  "typings": "./src/index.ts",
+  "typings": "./dist/index.d.ts",
   "repository": "https://github.com/camptocamp/ogc-client",
   "homepage": "https://github.com/camptocamp/ogc-client",
   "files": [
@@ -60,7 +60,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "npm run lint -- --fix",
-    "build": "npm run build:worker && npm run build:node && npm run build:browser",
+    "build": "rm -rf dist && npm run build:worker && npm run build:node && npm run build:browser",
     "build:browser": "esbuild $(find ./src -name \"*.ts\" -type f -not -path '*worker/index.ts' -not -path '*.spec.ts') --outdir=./dist --platform=neutral --format=esm --sourcemap",
     "build:node": "vite build --config vite.node-config.js",
     "build:worker": "vite build --config vite.worker-config.js",

--- a/vite.node-config.js
+++ b/vite.node-config.js
@@ -12,6 +12,7 @@ export default defineConfig({
         globals: (name) => name,
       },
     },
+    emptyOutDir: false,
     outDir: 'dist',
     minify: false,
   },

--- a/vite.worker-config.js
+++ b/vite.worker-config.js
@@ -3,8 +3,10 @@ import dts from 'vite-plugin-dts';
 
 export default defineConfig({
   plugins: [
+    // note: this will generate d.ts files for all the library
     dts({
       include: ['./src/**/*'],
+      exclude: ['./src/**/*.spec.ts'],
     }),
   ],
   build: {
@@ -13,6 +15,7 @@ export default defineConfig({
       formats: ['es'],
       fileName: `worker/index`,
     },
+    emptyOutDir: false,
     rollupOptions: {
       external: [/^ol/, 'proj4'],
       output: {


### PR DESCRIPTION
Reverts #61 as it is not recommended to publish TS files in a lib without d.ts files.

The build process now does not clear the dist folder between builds, which used to not make sense.