### PR TITLE
Add info formats to WMS capabilities

### DIFF
--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -17,6 +17,11 @@ export type GenericEndpointInfo = {
    * or the list of 'Formats' from a WMS GetCapabilities
    */
   outputFormats?: MimeType[];
+  /**
+   * Contains a list of formats that can be used for WMS GetFeatureInfo,
+   * or null for other services such as WFS
+   */
+  infoFormats?: MimeType[];
 };
 
 export type MimeType = string;

--- a/src/wms/capabilities.spec.ts
+++ b/src/wms/capabilities.spec.ts
@@ -297,10 +297,7 @@ describe('WMS capabilities', () => {
         'application/x-pdf',
         'image/svg+xml',
       ],
-      infoFormats: [
-        "text/plain",
-        "application/vnd.ogc.gml",
-      ],
+      infoFormats: ['text/plain', 'application/vnd.ogc.gml'],
       keywords: [
         'Géologie',
         'BRGM',

--- a/src/wms/capabilities.spec.ts
+++ b/src/wms/capabilities.spec.ts
@@ -297,6 +297,10 @@ describe('WMS capabilities', () => {
         'application/x-pdf',
         'image/svg+xml',
       ],
+      infoFormats: [
+        "text/plain",
+        "application/vnd.ogc.gml",
+      ],
       keywords: [
         'Géologie',
         'BRGM',

--- a/src/wms/capabilities.ts
+++ b/src/wms/capabilities.ts
@@ -57,6 +57,21 @@ export function readOutputFormatsFromCapabilities(
   return outputFormats;
 }
 
+export function readInfoFormatsFromCapabilities(capabilitiesDoc: XmlDocument) {
+  const capability = findChildElement(
+    getRootElement(capabilitiesDoc),
+    'Capability'
+  );
+  const getFeatureInfo = findChildElement(
+    findChildElement(capability, 'Request'),
+    'GetFeatureInfo'
+  );
+  const outputFormats = findChildrenElement(getFeatureInfo, 'Format').map(
+    getElementText
+  );
+  return outputFormats;
+}
+
 /**
  * Will read service-related info from the capabilities doc
  * @param capabilitiesDoc Capabilities document
@@ -66,7 +81,8 @@ export function readInfoFromCapabilities(
   capabilitiesDoc: XmlDocument
 ): GenericEndpointInfo {
   const service = findChildElement(getRootElement(capabilitiesDoc), 'Service');
-  const formats = readOutputFormatsFromCapabilities(capabilitiesDoc);
+  const outputFormats = readOutputFormatsFromCapabilities(capabilitiesDoc);
+  const infoFormats = readInfoFormatsFromCapabilities(capabilitiesDoc);
   const keywords = findChildrenElement(
     findChildElement(service, 'KeywordList'),
     'Keyword'
@@ -78,7 +94,8 @@ export function readInfoFromCapabilities(
     title: getElementText(findChildElement(service, 'Title')),
     name: getElementText(findChildElement(service, 'Name')),
     abstract: getElementText(findChildElement(service, 'Abstract')),
-    outputFormats: formats,
+    outputFormats: outputFormats,
+    infoFormats: infoFormats,
     fees: getElementText(findChildElement(service, 'Fees')),
     constraints: getElementText(findChildElement(service, 'AccessConstraints')),
     keywords,

--- a/src/wms/endpoint.spec.ts
+++ b/src/wms/endpoint.spec.ts
@@ -187,10 +187,7 @@ describe('WmsEndpoint', () => {
           'application/x-pdf',
           'image/svg+xml',
         ],
-        infoFormats: [
-          "text/plain",
-          "application/vnd.ogc.gml",
-        ],
+        infoFormats: ['text/plain', 'application/vnd.ogc.gml'],
         keywords: [
           'Géologie',
           'BRGM',

--- a/src/wms/endpoint.spec.ts
+++ b/src/wms/endpoint.spec.ts
@@ -187,6 +187,10 @@ describe('WmsEndpoint', () => {
           'application/x-pdf',
           'image/svg+xml',
         ],
+        infoFormats: [
+          "text/plain",
+          "application/vnd.ogc.gml",
+        ],
         keywords: [
           'Géologie',
           'BRGM',


### PR DESCRIPTION
This PR adds `infoFormats` as a property to the capabilities model. `infoFormats` are derived from the WMS GetFeatureInfo formats list and provide a list of formats (MIME types) that can be used in GetFeatureInfo requests. 

This has been added to the `GenericEndpointInfo` class, however, this list is only retrieved in WMS scenarios, so this may not be the right place. Happy to take suggestions on a more appropriate place for this. 