### PR TITLE
Add support for retrieving exception formats from WMS capabilities

### DIFF
--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -22,6 +22,11 @@ export type GenericEndpointInfo = {
    * or null for other services such as WFS
    */
   infoFormats?: MimeType[];
+  /**
+   * Contains a list of formats that can be used for Exceptions for WMS GetMap,
+   * or undefined for other services such as WFS
+   */
+  exceptionFormats?: MimeType[] | string[];
 };
 
 export type MimeType = string;

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -19,7 +19,7 @@ export type GenericEndpointInfo = {
   outputFormats?: MimeType[];
   /**
    * Contains a list of formats that can be used for WMS GetFeatureInfo,
-   * or null for other services such as WFS
+   * or undefined for other services such as WFS
    */
   infoFormats?: MimeType[];
   /**

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -17,6 +17,11 @@ export type GenericEndpointInfo = {
    * or the list of 'Formats' from a WMS GetCapabilities
    */
   outputFormats?: MimeType[];
+  /**
+   * Contains a list of formats that can be used for WMS GetFeatureInfo,
+   * or null for other services such as WFS
+   */
+  infoFormats?: MimeType[];
 };
 
 export type MimeType = string;

--- a/src/wms/capabilities.spec.ts
+++ b/src/wms/capabilities.spec.ts
@@ -297,10 +297,7 @@ describe('WMS capabilities', () => {
         'application/x-pdf',
         'image/svg+xml',
       ],
-      infoFormats: [
-        "text/plain",
-        "application/vnd.ogc.gml",
-      ],
+      infoFormats: ['text/plain', 'application/vnd.ogc.gml'],
       keywords: [
         'Géologie',
         'BRGM',

--- a/src/wms/capabilities.spec.ts
+++ b/src/wms/capabilities.spec.ts
@@ -297,6 +297,10 @@ describe('WMS capabilities', () => {
         'application/x-pdf',
         'image/svg+xml',
       ],
+      infoFormats: [
+        "text/plain",
+        "application/vnd.ogc.gml",
+      ],
       keywords: [
         'Géologie',
         'BRGM',

--- a/src/wms/capabilities.spec.ts
+++ b/src/wms/capabilities.spec.ts
@@ -298,6 +298,9 @@ describe('WMS capabilities', () => {
         'image/svg+xml',
       ],
       infoFormats: ['text/plain', 'application/vnd.ogc.gml'],
+      exceptionFormats: [
+        /* these differ depending on the WMS version used */
+      ],
       keywords: [
         'Géologie',
         'BRGM',
@@ -311,11 +314,17 @@ describe('WMS capabilities', () => {
 
     it('reads the service info (1.3.0)', () => {
       const doc = parseXmlString(capabilities130);
+      expectedInfo.exceptionFormats = ['XML', 'INIMAGE', 'BLANK'];
       expect(readInfoFromCapabilities(doc)).toEqual(expectedInfo);
     });
 
     it('reads the service info (1.1.1)', () => {
       const doc = parseXmlString(capabilities111);
+      expectedInfo.exceptionFormats = [
+        'application/vnd.ogc.se_xml',
+        'application/vnd.ogc.se_inimage',
+        'application/vnd.ogc.se_blank',
+      ];
       expect(readInfoFromCapabilities(doc)).toEqual(expectedInfo);
     });
   });

--- a/src/wms/capabilities.ts
+++ b/src/wms/capabilities.ts
@@ -57,6 +57,21 @@ export function readOutputFormatsFromCapabilities(
   return outputFormats;
 }
 
+export function readInfoFormatsFromCapabilities(capabilitiesDoc: XmlDocument) {
+  const capability = findChildElement(
+    getRootElement(capabilitiesDoc),
+    'Capability'
+  );
+  const getFeatureInfo = findChildElement(
+    findChildElement(capability, 'Request'),
+    'GetFeatureInfo'
+  );
+  const outputFormats = findChildrenElement(getFeatureInfo, 'Format').map(
+    getElementText
+  );
+  return outputFormats;
+}
+
 /**
  * Will read service-related info from the capabilities doc
  * @param capabilitiesDoc Capabilities document
@@ -66,7 +81,8 @@ export function readInfoFromCapabilities(
   capabilitiesDoc: XmlDocument
 ): GenericEndpointInfo {
   const service = findChildElement(getRootElement(capabilitiesDoc), 'Service');
-  const formats = readOutputFormatsFromCapabilities(capabilitiesDoc);
+  const outputFormats = readOutputFormatsFromCapabilities(capabilitiesDoc);
+  const infoFormats = readInfoFormatsFromCapabilities(capabilitiesDoc);
   const keywords = findChildrenElement(
     findChildElement(service, 'KeywordList'),
     'Keyword'
@@ -78,7 +94,8 @@ export function readInfoFromCapabilities(
     title: getElementText(findChildElement(service, 'Title')),
     name: getElementText(findChildElement(service, 'Name')),
     abstract: getElementText(findChildElement(service, 'Abstract')),
-    outputFormats: formats,
+    outputFormats: outputFormats,
+    infoFormats: infoFormats,
     fees: getElementText(findChildElement(service, 'Fees')),
     constraints: getElementText(findChildElement(service, 'AccessConstraints')),
     keywords,

--- a/src/wms/capabilities.ts
+++ b/src/wms/capabilities.ts
@@ -73,6 +73,25 @@ export function readInfoFormatsFromCapabilities(capabilitiesDoc: XmlDocument) {
 }
 
 /**
+ * Will return all available exception formats
+ * @param capabilitiesDoc Capabiliites document
+ * @return Available exception formats
+ */
+export function readExceptionFormatsFromCapabilities(
+  capabilitiesDoc: XmlDocument
+) {
+  const capability = findChildElement(
+    getRootElement(capabilitiesDoc),
+    'Capability'
+  );
+  const exception = findChildElement(capability, 'Exception');
+  const exceptionFormats = findChildrenElement(exception, 'Format').map(
+    getElementText
+  );
+  return exceptionFormats;
+}
+
+/**
  * Will read service-related info from the capabilities doc
  * @param capabilitiesDoc Capabilities document
  * @return Parsed service info
@@ -83,6 +102,8 @@ export function readInfoFromCapabilities(
   const service = findChildElement(getRootElement(capabilitiesDoc), 'Service');
   const outputFormats = readOutputFormatsFromCapabilities(capabilitiesDoc);
   const infoFormats = readInfoFormatsFromCapabilities(capabilitiesDoc);
+  const exceptionFormats =
+    readExceptionFormatsFromCapabilities(capabilitiesDoc);
   const keywords = findChildrenElement(
     findChildElement(service, 'KeywordList'),
     'Keyword'
@@ -96,6 +117,7 @@ export function readInfoFromCapabilities(
     abstract: getElementText(findChildElement(service, 'Abstract')),
     outputFormats: outputFormats,
     infoFormats: infoFormats,
+    exceptionFormats: exceptionFormats,
     fees: getElementText(findChildElement(service, 'Fees')),
     constraints: getElementText(findChildElement(service, 'AccessConstraints')),
     keywords,

--- a/src/wms/endpoint.spec.ts
+++ b/src/wms/endpoint.spec.ts
@@ -187,10 +187,7 @@ describe('WmsEndpoint', () => {
           'application/x-pdf',
           'image/svg+xml',
         ],
-        infoFormats: [
-          "text/plain",
-          "application/vnd.ogc.gml",
-        ],
+        infoFormats: ['text/plain', 'application/vnd.ogc.gml'],
         keywords: [
           'Géologie',
           'BRGM',

--- a/src/wms/endpoint.spec.ts
+++ b/src/wms/endpoint.spec.ts
@@ -188,6 +188,7 @@ describe('WmsEndpoint', () => {
           'image/svg+xml',
         ],
         infoFormats: ['text/plain', 'application/vnd.ogc.gml'],
+        exceptionFormats: ['XML', 'INIMAGE', 'BLANK'],
         keywords: [
           'Géologie',
           'BRGM',

--- a/src/wms/endpoint.spec.ts
+++ b/src/wms/endpoint.spec.ts
@@ -187,6 +187,10 @@ describe('WmsEndpoint', () => {
           'application/x-pdf',
           'image/svg+xml',
         ],
+        infoFormats: [
+          "text/plain",
+          "application/vnd.ogc.gml",
+        ],
         keywords: [
           'Géologie',
           'BRGM',


### PR DESCRIPTION
This PR builds on #66 and adds additional support for retrieving the list of available Exception formats from WMS capabilities.

Although this list is usually static - varying depending only on the WMS version being used - according to the standard only the XML format is required and the image exception formats may therefore not be available on a given WMS endpoint.

Note that I have deliberately set the type definition for `exceptionFormats` to `MimeType[] | string[]` because the WMS 1.3.0 spec does not use MIME-like syntax for the format strings.