### PR TITLE
Expose WMS Layer and WFS FeatureType MetadataURLs

### DIFF
--- a/fixtures/wfs/capabilities-pigma-1-0-0.xml
+++ b/fixtures/wfs/capabilities-pigma-1-0-0.xml
@@ -209,6 +209,9 @@
             <SRS>EPSG:2154</SRS>
             <LatLongBoundingBox minx="-1.9540704007796161" miny="42.73286181824404" maxx="1.496463327812538"
                                 maxy="45.717071228823876"/>
+            <MetadataURL type="TC211" format="text/plain">
+                https://www.pigma.org/geonetwork/?uuid=cbcae9a4-7fc0-4fc8-bd78-089af3af4e8a
+            </MetadataURL>
         </FeatureType>
         <FeatureType>
             <Name>cd16:comptages_routiers_l</Name>
@@ -222,6 +225,15 @@
             <SRS>EPSG:2154</SRS>
             <LatLongBoundingBox minx="-0.4906009184568518" miny="45.175543885638376" maxx="0.9778719979726385"
                                 maxy="46.14349349624617"/>
+            <MetadataURL type="TC211" format="text/html">
+                https://www.pigma.org/geonetwork?uuid=4d840710-3f09-4f48-aa31-d2c4c0ee6fda
+            </MetadataURL>
+            <MetadataURL type="19115" format="text/html">
+                https://www.pigma.org/geonetwork?uuid=4d840710-3f09-4f48-aa31-d2c4c0ee6fda
+            </MetadataURL>
+            <MetadataURL type="19115" format="text/xml">
+                https://www.pigma.org/geonetwork/srv/fre/xml_iso19139?uuid=4d840710-3f09-4f48-aa31-d2c4c0ee6fda
+            </MetadataURL>
         </FeatureType>
         <FeatureType>
             <Name>cd16:hierarchisation_l</Name>
@@ -235,6 +247,15 @@
             <SRS>EPSG:2154</SRS>
             <LatLongBoundingBox minx="-0.4832134559131876" miny="45.18037755571674" maxx="0.9725372441782966"
                                 maxy="46.13877580094452"/>
+            <MetadataURL type="TC211" format="text/html">
+                https://www.pigma.org/geonetwork?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6
+            </MetadataURL>
+            <MetadataURL type="19115" format="text/html">
+                https://www.pigma.org/geonetwork?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6
+            </MetadataURL>
+            <MetadataURL type="19115" format="text/xml">
+                https://www.pigma.org/geonetwork/srv/fre/xml_iso19139?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6
+            </MetadataURL>
         </FeatureType>
     </FeatureTypeList>
     <ogc:Filter_Capabilities>

--- a/fixtures/wfs/capabilities-pigma-2-0-0.xml
+++ b/fixtures/wfs/capabilities-pigma-2-0-0.xml
@@ -450,9 +450,6 @@
                 <ows:UpperCorner>1.496463327812538 45.717071228823876</ows:UpperCorner>
             </ows:WGS84BoundingBox>
             <MetadataURL xlink:href="https://www.pigma.org/geonetwork/?uuid=cbcae9a4-7fc0-4fc8-bd78-089af3af4e8a"/>
-            <MetadataURL xlink:href="https://www.pigma.org/geonetwork/?uuid=cbcae9a4-7fc0-4fc8-bd78-089af3af4e8a"/>
-            <MetadataURL
-                    xlink:href="https://www.pigma.org/geonetwork/srv/fre/xml_iso19139?uuid=cbcae9a4-7fc0-4fc8-bd78-089af3af4e8a"/>
             <OutputFormats>
                 <Format>application/gml+xml; version=3.2</Format>
                 <Format>text/xml; subtype=gml/3.2.1</Format>

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -39,3 +39,9 @@ export interface LayerStyle {
    */
   legendUrl?: string;
 }
+
+export type MetadataURL = {
+  format?: string;
+  type?: string;
+  url: string;
+};

--- a/src/wfs/capabilities.spec.ts
+++ b/src/wfs/capabilities.spec.ts
@@ -40,6 +40,13 @@ describe('WFS capabilities', () => {
           -1.9540704007796161, 42.73286181824404, 1.496463327812538,
           45.717071228823876,
         ],
+        metadata: [
+          {
+            format: 'text/plain',
+            type: 'TC211',
+            url: 'https://www.pigma.org/geonetwork/?uuid=cbcae9a4-7fc0-4fc8-bd78-089af3af4e8a',
+          },
+        ],
         name: 'asp:asp_rpg2010',
         otherCrs: ['EPSG:32615', 'EPSG:32616', 'EPSG:32617', 'EPSG:32618'],
         outputFormats: [
@@ -58,6 +65,23 @@ describe('WFS capabilities', () => {
         latLonBoundingBox: [
           -0.4906009184568518, 45.175543885638376, 0.9778719979726385,
           46.14349349624617,
+        ],
+        metadata: [
+          {
+            format: 'text/html',
+            type: 'TC211',
+            url: 'https://www.pigma.org/geonetwork?uuid=4d840710-3f09-4f48-aa31-d2c4c0ee6fda',
+          },
+          {
+            format: 'text/html',
+            type: '19115',
+            url: 'https://www.pigma.org/geonetwork?uuid=4d840710-3f09-4f48-aa31-d2c4c0ee6fda',
+          },
+          {
+            format: 'text/xml',
+            type: '19115',
+            url: 'https://www.pigma.org/geonetwork/srv/fre/xml_iso19139?uuid=4d840710-3f09-4f48-aa31-d2c4c0ee6fda',
+          },
         ],
         name: 'cd16:comptages_routiers_l',
         otherCrs: ['EPSG:32615', 'EPSG:32616', 'EPSG:32617', 'EPSG:32618'],
@@ -80,6 +104,23 @@ describe('WFS capabilities', () => {
           46.13877580094452,
         ],
         name: 'cd16:hierarchisation_l',
+        metadata: [
+          {
+            format: 'text/html',
+            type: 'TC211',
+            url: 'https://www.pigma.org/geonetwork?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6',
+          },
+          {
+            format: 'text/html',
+            type: '19115',
+            url: 'https://www.pigma.org/geonetwork?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6',
+          },
+          {
+            format: 'text/xml',
+            type: '19115',
+            url: 'https://www.pigma.org/geonetwork/srv/fre/xml_iso19139?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6',
+          },
+        ],
         otherCrs: ['EPSG:32615', 'EPSG:32616', 'EPSG:32617', 'EPSG:32618'],
         outputFormats: [
           'application/gml+xml; version=3.2',
@@ -92,7 +133,13 @@ describe('WFS capabilities', () => {
     ];
     it('reads the feature types (2.0.0)', () => {
       const doc = parseXmlString(capabilities200);
-      expect(readFeatureTypesFromCapabilities(doc)).toEqual(expectedTypes);
+      const typesWithoutMetadataUrlAttributes = expectedTypes.map((type) => ({
+        ...type,
+        metadata: type.metadata.map((metadata) => ({ url: metadata.url })),
+      }));
+      expect(readFeatureTypesFromCapabilities(doc)).toEqual(
+        typesWithoutMetadataUrlAttributes
+      );
     });
     it('reads the feature types (1.1.0)', () => {
       const doc = parseXmlString(capabilities110);
@@ -138,6 +185,20 @@ describe('WFS capabilities', () => {
           latLonBoundingBox: [
             1.3472171890368316, 48.82764887581316, 4.285589467078578,
             51.0896786738123,
+          ],
+          metadata: [
+            {
+              url: 'https://www.geo2france.fr/geonetwork/srv/fre/catalog.search#/metadata/facf3747-bc19-44c7-9fd8-1f765d99c059',
+            },
+            {
+              url: 'https://www.geo2france.fr/geonetwork/srv/fre/catalog.search#/metadata/facf3747-bc19-44c7-9fd8-1f765d99c059',
+            },
+            {
+              url: 'https://www.geo2france.fr/geonetwork/srv/api/records/facf3747-bc19-44c7-9fd8-1f765d99c059/formatters/xml',
+            },
+            {
+              url: 'https://www.geo2france.fr/geonetwork/srv/api/records/facf3747-bc19-44c7-9fd8-1f765d99c059/formatters/xml',
+            },
           ],
           name: 'cr_hdf:domaine_public_hdf_com',
           otherCrs: [],

--- a/src/wfs/capabilities.ts
+++ b/src/wfs/capabilities.ts
@@ -168,6 +168,22 @@ function parseFeatureType(
       )
         .map(getElementText)
         .filter((v, i, arr) => arr.indexOf(v) === i);
+
+  const metadata =
+    serviceVersion === '2.0.0'
+      ? findChildrenElement(featureTypeEl, 'MetadataURL').map(
+          (metadataUrlEl) => ({
+            url: getElementAttribute(metadataUrlEl, 'xlink:href'),
+          })
+        )
+      : findChildrenElement(featureTypeEl, 'MetadataURL').map(
+          (metadataUrlEl) => ({
+            format: getElementAttribute(metadataUrlEl, 'format'),
+            type: getElementAttribute(metadataUrlEl, 'type'),
+            url: getElementText(metadataUrlEl).trim(),
+          })
+        );
+
   return {
     name: getElementText(findChildElement(featureTypeEl, 'Name')),
     title: getElementText(findChildElement(featureTypeEl, 'Title')),
@@ -182,5 +198,6 @@ function parseFeatureType(
       ? parseBBox100()
       : parseBBox(),
     keywords: keywords,
+    ...(metadata.length && { metadata }),
   };
 }

--- a/src/wfs/endpoint.spec.ts
+++ b/src/wfs/endpoint.spec.ts
@@ -132,6 +132,17 @@ describe('WfsEndpoint', () => {
         ],
         defaultCrs: 'EPSG:2154',
         keywords: ['features', 'hierarchisation_l'],
+        metadata: [
+          {
+            url: 'https://www.pigma.org/geonetwork?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6',
+          },
+          {
+            url: 'https://www.pigma.org/geonetwork?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6',
+          },
+          {
+            url: 'https://www.pigma.org/geonetwork/srv/fre/xml_iso19139?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6',
+          },
+        ],
         otherCrs: ['EPSG:32615', 'EPSG:32616', 'EPSG:32617', 'EPSG:32618'],
         outputFormats: [
           'application/gml+xml; version=3.2',
@@ -172,6 +183,17 @@ describe('WfsEndpoint', () => {
         ],
         defaultCrs: 'EPSG:2154',
         keywords: ['features', 'hierarchisation_l'],
+        metadata: [
+          {
+            url: 'https://www.pigma.org/geonetwork?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6',
+          },
+          {
+            url: 'https://www.pigma.org/geonetwork?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6',
+          },
+          {
+            url: 'https://www.pigma.org/geonetwork/srv/fre/xml_iso19139?uuid=cd27adaa-0ec5-4934-9374-143df09fb9f6',
+          },
+        ],
         otherCrs: ['EPSG:32615', 'EPSG:32616', 'EPSG:32617', 'EPSG:32618'],
         outputFormats: [
           'application/gml+xml; version=3.2',

--- a/src/wfs/endpoint.ts
+++ b/src/wfs/endpoint.ts
@@ -125,6 +125,7 @@ export default class WfsEndpoint {
       otherCrs: featureType.otherCrs,
       outputFormats: featureType.outputFormats,
       keywords: featureType.keywords,
+      ...('metadata' in featureType && { metadata: featureType.metadata }),
     } as WfsFeatureTypeSummary;
   }
 

--- a/src/wfs/featuretypeinfo.ts
+++ b/src/wfs/featuretypeinfo.ts
@@ -31,6 +31,7 @@ export function parseFeatureTypeInfo(
     outputFormats,
     latLonBoundingBox: boundingBox,
     keywords,
+    metadata,
   } = featureType;
 
   const hitsAttr = serviceVersion.startsWith('2.0')
@@ -79,6 +80,7 @@ export function parseFeatureTypeInfo(
     ...(geometryType && { geometryType }),
     ...(!Number.isNaN(objectCount) && { objectCount }),
     ...(keywords && { keywords }),
+    ...(metadata && { metadata }),
   };
 }
 

--- a/src/wfs/model.ts
+++ b/src/wfs/model.ts
@@ -1,4 +1,9 @@
-import { BoundingBox, CrsCode, MimeType } from '../shared/models.js';
+import {
+  BoundingBox,
+  CrsCode,
+  MetadataURL,
+  MimeType,
+} from '../shared/models.js';
 
 export type WfsVersion = '1.0.0' | '1.1.0' | '2.0.0';
 
@@ -11,6 +16,7 @@ export type WfsFeatureTypeInternal = {
   outputFormats: MimeType[];
   latLonBoundingBox?: BoundingBox;
   keywords?: string[];
+  metadata?: MetadataURL[];
 };
 
 export type FeaturePropertyType = string | number | boolean;
@@ -46,6 +52,7 @@ export type WfsFeatureTypeSummary = {
   otherCrs: CrsCode[];
   outputFormats: MimeType[];
   keywords?: string[];
+  metadata?: MetadataURL[];
 };
 
 export type WfsFeatureTypeFull = {

--- a/src/wms/capabilities.spec.ts
+++ b/src/wms/capabilities.spec.ts
@@ -132,6 +132,13 @@ describe('WMS capabilities', () => {
                   'EPSG:4326': ['-5.86764', '41.1701', '11.0789', '51.1419'],
                 },
                 keywords: ['Geologie', 'INSPIRE:Geology', 'Geology'],
+                metadata: [
+                  {
+                    format: 'text/xml',
+                    type: 'TC211',
+                    url: 'http://www.geocatalogue.fr/api-public/servicesRest?Service=CSW&Request=GetRecordById&Version=2.0.2&id=BR_CAR_ADA&outputSchema=http://www.isotc211.org/2005/gmd&elementSetName=full',
+                  },
+                ],
                 name: 'SCAN_F_GEOL1M',
                 queryable: false,
                 opaque: false,
@@ -186,6 +193,13 @@ describe('WMS capabilities', () => {
                 },
                 keywords: ['Geologie', 'INSPIRE:Geology', 'Geology'],
                 name: 'SCAN_F_GEOL250',
+                metadata: [
+                  {
+                    format: 'text/xml',
+                    type: 'TC211',
+                    url: 'http://www.geocatalogue.fr/api-public/servicesRest?Service=CSW&Request=GetRecordById&Version=2.0.2&id=BR_CAR_ACA&outputSchema=http://www.isotc211.org/2005/gmd&elementSetName=full',
+                  },
+                ],
                 queryable: true,
                 opaque: true,
                 styles,
@@ -226,6 +240,13 @@ describe('WMS capabilities', () => {
                 },
                 keywords: ['Geologie', 'INSPIRE:Geology', 'Geology'],
                 name: 'SCAN_D_GEOL50',
+                metadata: [
+                  {
+                    format: 'text/xml',
+                    type: 'TC211',
+                    url: 'http://www.geocatalogue.fr/api-public/servicesRest?Service=CSW&Request=GetRecordById&Version=2.0.2&id=72cc8d40-1bb6-41a3-8376-9734f23336ff&outputSchema=http://www.isotc211.org/2005/gmd&elementSetName=full',
+                  },
+                ],
                 queryable: true,
                 opaque: true,
                 styles,

--- a/src/wms/capabilities.ts
+++ b/src/wms/capabilities.ts
@@ -169,6 +169,17 @@ function parseLayer(
     .map(getElementText)
     .filter((v, i, arr) => arr.indexOf(v) === i);
 
+  const metadata = findChildrenElement(layerEl, 'MetadataURL').map(
+    (metadataUrlEl) => ({
+      type: getElementAttribute(metadataUrlEl, 'type'),
+      format: getElementText(findChildElement(metadataUrlEl, 'Format')),
+      url: getElementAttribute(
+        findChildElement(metadataUrlEl, 'OnlineResource'),
+        'xlink:href'
+      ),
+    })
+  );
+
   const children = findChildrenElement(layerEl, 'Layer').map((layer) =>
     parseLayer(layer, version, availableCrs, styles, attribution, boundingBoxes)
   );
@@ -183,6 +194,7 @@ function parseLayer(
     keywords,
     queryable,
     opaque,
+    ...(metadata.length && { metadata }),
     ...(children.length && { children }),
   };
 }

--- a/src/wms/model.ts
+++ b/src/wms/model.ts
@@ -1,15 +1,14 @@
-import { BoundingBox, CrsCode, LayerStyle } from '../shared/models.js';
+import {
+  BoundingBox,
+  CrsCode,
+  LayerStyle,
+  type MetadataURL,
+} from '../shared/models.js';
 
 export type WmsLayerAttribution = {
   title?: string;
   url?: string;
   logoUrl?: string;
-};
-
-export type WmsLayerMetadata = {
-  type: string;
-  format: string;
-  url: string;
 };
 
 export type WmsLayerSummary = {
@@ -42,7 +41,7 @@ export type WmsLayerFull = {
   opaque: boolean;
   attribution?: WmsLayerAttribution;
   keywords?: string[];
-  metadata?: WmsLayerMetadata[];
+  metadata?: MetadataURL[];
   /**
    * Not defined if the layer is a leaf in the tree
    */

--- a/src/wms/model.ts
+++ b/src/wms/model.ts
@@ -6,6 +6,12 @@ export type WmsLayerAttribution = {
   logoUrl?: string;
 };
 
+export type WmsLayerMetadata = {
+  type: string;
+  format: string;
+  url: string;
+};
+
 export type WmsLayerSummary = {
   /**
    * The layer is renderable if defined
@@ -36,6 +42,7 @@ export type WmsLayerFull = {
   opaque: boolean;
   attribution?: WmsLayerAttribution;
   keywords?: string[];
+  metadata?: WmsLayerMetadata[];
   /**
    * Not defined if the layer is a leaf in the tree
    */


### PR DESCRIPTION
Applications may want to provide links to available metadata of layers and feature types shown. For this to be possible it is necessary to expose the relevant elements in the API.

Note that some changes to test fixtures were required in order to harmonise the `MetadataURL` elements included in different WFS versions.