### PR TITLE
Allow using xs: prefix for feature type attributes

### DIFF
--- a/fixtures/wfs/describefeaturetype-pigma-1-1-0-xsd.xml
+++ b/fixtures/wfs/describefeaturetype-pigma-1-1-0-xsd.xml
@@ -4,14 +4,14 @@
         <xsd:complexContent>
             <xsd:extension base="gml:AbstractFeatureType">
                 <xsd:sequence>
-                    <xsd:element maxOccurs="1" minOccurs="0" name="axe" nillable="true" type="xsd:string"/>
-                    <xsd:element maxOccurs="1" minOccurs="0" name="cumuld" nillable="true" type="xsd:long"/>
-                    <xsd:element maxOccurs="1" minOccurs="0" name="cumulf" nillable="true" type="xsd:long"/>
-                    <xsd:element maxOccurs="1" minOccurs="0" name="plod" nillable="true" type="xsd:string"/>
-                    <xsd:element maxOccurs="1" minOccurs="0" name="absd" nillable="true" type="xsd:long"/>
-                    <xsd:element maxOccurs="1" minOccurs="0" name="plof" nillable="true" type="xsd:string"/>
-                    <xsd:element maxOccurs="1" minOccurs="0" name="absf" nillable="true" type="xsd:long"/>
-                    <xsd:element maxOccurs="1" minOccurs="0" name="categorie" nillable="true" type="xsd:short"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="axe" nillable="true" type="xs:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="cumuld" nillable="true" type="xs:long"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="cumulf" nillable="true" type="xs:long"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="plod" nillable="true" type="xs:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="absd" nillable="true" type="xs:long"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="plof" nillable="true" type="xs:string"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="absf" nillable="true" type="xs:long"/>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="categorie" nillable="true" type="xs:short"/>
                     <xsd:element maxOccurs="1" minOccurs="0" name="geom" nillable="true" type="gml:LineStringPropertyType"/>
                 </xsd:sequence>
             </xsd:extension>

--- a/src/wfs/featuretypeinfo.ts
+++ b/src/wfs/featuretypeinfo.ts
@@ -47,7 +47,7 @@ export function parseFeatureTypeInfo(
   )[0];
   const typeElementsEls = findChildrenElement(complexTypeEl, 'element', true);
   const properties = typeElementsEls
-    .filter((el) => getElementAttribute(el, 'type').startsWith('xsd:'))
+    .filter((el) => /^xsd:|^xs:/.test(getElementAttribute(el, 'type')))
     .reduce(
       (prev, curr) => ({
         ...prev,


### PR DESCRIPTION
Hopefully this will be enough to cover all server implementations. An alternative is to read which prefix is used for the XSD namespace and check for that, but for now we can try like that.

Fixes #75