### PR TITLE
Fix wrong crs for wmts layer

### DIFF
--- a/src/wmts/capabilities.spec.ts
+++ b/src/wmts/capabilities.spec.ts
@@ -614,7 +614,7 @@ describe('WMTS Capabilities', () => {
             matrixSets: [
               {
                 identifier: 'BigWorldPixel',
-                crs: 'urn:ogc:def:crs:EPSG:6.18:3:3857',
+                crs: 'urn:ogc:def:crs:OGC:1.3:CRS84',
                 limits: [],
               },
               {
@@ -681,7 +681,7 @@ describe('WMTS Capabilities', () => {
               },
               {
                 identifier: 'GoogleMapsCompatible',
-                crs: 'urn:ogc:def:crs:EPSG::3857',
+                crs: 'urn:ogc:def:crs:EPSG:6.18.3:3857',
                 limits: [],
               },
             ],

--- a/src/wmts/capabilities.ts
+++ b/src/wmts/capabilities.ts
@@ -119,13 +119,13 @@ export function readLayersFromCapabilities(
 ): WmtsLayer[] {
   const rootEl = getRootElement(capabilitiesDoc);
   const contentsEl = findChildElement(rootEl, 'Contents');
-  
-/**
- * Get the TileMatrixSet CRS
- * @param contentsEl - Contents
- * @param identifier - TileMatrixSet identifier
- * @returns The SupportedCRS of the TileMatrixSet
- */
+
+  /**
+   * Get the TileMatrixSet CRS
+   * @param contentsEl - Contents
+   * @param identifier - TileMatrixSet identifier
+   * @returns The SupportedCRS of the TileMatrixSet
+   */
   function getMatrixSetCrs(contentsEl: XmlElement, identifier: string): string {
     const matrixSet = findChildrenElement(contentsEl, 'TileMatrixSet').find(
       (matrixSetEl) => {
@@ -135,16 +135,18 @@ export function readLayersFromCapabilities(
     );
     return getElementText(findChildElement(matrixSet, 'SupportedCRS'));
   }
-  
+
   /**
    * Get the parameters of the TileMatrixSetLink
-   * @param element - TileMatrixSetLink 
+   * @param element - TileMatrixSetLink
    * @returns
    */
   function parseMatrixSetLink(element: XmlElement): MatrixSetLink {
-    const identifier = getElementText(findChildElement(element, 'TileMatrixSet'));
+    const identifier = getElementText(
+      findChildElement(element, 'TileMatrixSet')
+    );
     const crs = getMatrixSetCrs(contentsEl, identifier);
-    
+
     return {
       identifier,
       crs,


### PR DESCRIPTION
ACCES.BIOMETHANE layer from this service : https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0 shows these informations:
```
Identifier
    PM_6_16
Crs
    EPSG:2154
```
But the CRS should be EPSG:3857 instead of EPSG:2154.

This PR aims to correct this behaviour. Let me know if I need to make any changes to the code.