### PR TITLE
Return error object instead of message

### DIFF
--- a/src/wfs/endpoint.spec.ts
+++ b/src/wfs/endpoint.spec.ts
@@ -80,9 +80,9 @@ describe('WfsEndpoint', () => {
         endpoint = new WfsEndpoint('https://my.test.service/ogc/wms');
       });
       it('rejects when the endpoint returns an exception report', async () => {
-        await expect(endpoint.isReady()).rejects.toThrow(
-          'msWFSDispatch(): WFS server error. WFS request not enabled. Check wfs/ows_enable_request settings.'
-        );
+        await expect(endpoint.isReady()).rejects.toMatchObject({
+          message: 'msWFSDispatch(): WFS server error. WFS request not enabled. Check wfs/ows_enable_request settings.'
+        });
       });
     });
   });

--- a/src/wfs/endpoint.spec.ts
+++ b/src/wfs/endpoint.spec.ts
@@ -81,7 +81,8 @@ describe('WfsEndpoint', () => {
       });
       it('rejects when the endpoint returns an exception report', async () => {
         await expect(endpoint.isReady()).rejects.toMatchObject({
-          message: 'msWFSDispatch(): WFS server error. WFS request not enabled. Check wfs/ows_enable_request settings.'
+          message:
+            'msWFSDispatch(): WFS server error. WFS request not enabled. Check wfs/ows_enable_request settings.',
         });
       });
     });

--- a/src/wms/endpoint.spec.ts
+++ b/src/wms/endpoint.spec.ts
@@ -61,7 +61,8 @@ describe('WmsEndpoint', () => {
       });
       it('rejects when the endpoint returns an exception report', async () => {
         await expect(endpoint.isReady()).rejects.toMatchObject({
-          message: 'msWMSGetCapabilities(): WMS server error. WMS request not enabled. Check wms/ows_enable_request settings.',
+          message:
+            'msWMSGetCapabilities(): WMS server error. WMS request not enabled. Check wms/ows_enable_request settings.',
         });
       });
     });

--- a/src/wms/endpoint.spec.ts
+++ b/src/wms/endpoint.spec.ts
@@ -60,9 +60,9 @@ describe('WmsEndpoint', () => {
         endpoint = new WmsEndpoint('https://my.test.service/ogc/wfs');
       });
       it('rejects when the endpoint returns an exception report', async () => {
-        await expect(endpoint.isReady()).rejects.toThrow(
-          'msWMSGetCapabilities(): WMS server error. WMS request not enabled. Check wms/ows_enable_request settings.'
-        );
+        await expect(endpoint.isReady()).rejects.toMatchObject({
+          message: 'msWMSGetCapabilities(): WMS server error. WMS request not enabled. Check wms/ows_enable_request settings.',
+        });
       });
     });
   });

--- a/src/worker/utils.ts
+++ b/src/worker/utils.ts
@@ -1,4 +1,5 @@
 import { getUniqueId } from '../shared/id.js';
+import { EndpointError } from '../shared/errors.js'
 
 type TaskParams = Record<string, unknown>;
 type TaskResponse = Record<string, unknown>;
@@ -76,11 +77,16 @@ export function addTaskHandler(
 
   const eventHandler = async (request: WorkerRequest) => {
     if (request.taskName === taskName) {
-      let response, error;
+      let response;
+      let error: EndpointError;
       try {
         response = await handler(request.params);
       } catch (e) {
-        error = e;
+        error = {
+          httpStatus: e.httpStatus,
+          message: e.message,
+          name: e.name
+        };
       }
       const message = /** @type {WorkerResponse} */ {
         taskName,

--- a/src/worker/utils.ts
+++ b/src/worker/utils.ts
@@ -1,5 +1,5 @@
 import { getUniqueId } from '../shared/id.js';
-import { EndpointError } from '../shared/errors.js'
+import { EndpointError } from '../shared/errors.js';
 
 type TaskParams = Record<string, unknown>;
 type TaskResponse = Record<string, unknown>;
@@ -85,7 +85,7 @@ export function addTaskHandler(
         error = {
           httpStatus: e.httpStatus,
           message: e.message,
-          name: e.name
+          name: e.name,
         };
       }
       const message = /** @type {WorkerResponse} */ {


### PR DESCRIPTION
Currently the error on endpoint only returns a message, and then the following `console.log(error.httpStatus)` returns `undefined`:
```ts
// someWrongUrl can be, for example: https://data.geopf.fr/wts?SERVICE=WMTS&VERSION=1.0.0
this.endpoint = new WmtsEndpoint(someWrongUrl);
try {
  await this.endpoint.isReady();
} catch (e) {
  console.log(e.httpStatus); 
  // returns undefined
  this.error = e.message;
  // returns a message
}
```
This behavior is due to the following line in `eventHandler` (utils.ts):

```ts
try {
  response = await handler(request.params);
} catch (e) {
  error = e;
}
```
It can be fixed as follows:
```ts
const eventHandler = async (request: WorkerRequest) => {
  if (request.taskName === taskName) {
    let response;

    // !! Update here !!
    let error: EndpointError;
    try {
      response = await handler(request.params);
    } catch (e) {

      // !! Update here !!
      error = {
        httpStatus: e.httpStatus,
        message: e.message,
        name: e.name
      };

    }
    const message = /** @type {WorkerResponse} */ {
      taskName,
      requestId: request.requestId,
      ...(response && { response }),
      ...(error && { error }),
    };
    if (useWorker) {
      scope.postMessage(message);
    } else {
      scope.dispatchEvent(
        new CustomEvent('ogc-client.response', {
          detail: message,
        })
      );
    }
  }
};
```

This pull request aims to return an error object that contains the error message in `error.message` and all other error information like `httpStatus`. Tests have been updated accordingly.

Let me know if i need to change/fix anything in the PR as i don't understand very well the eventHandler function