### PR TITLE
Better WMTS layer creation

### DIFF
--- a/app/src/Docs.vue
+++ b/app/src/Docs.vue
@@ -199,6 +199,7 @@ async function getFirstTenRecords() {
         <pre>
 import TileLayer from 'ol/layer/Tile';
 import WMTS from 'ol/source/WMTS';
+import { transformExtent } from 'ol/proj';
 import { WmtsEndpoint } from '@camptocamp/ogc-client';
 
 // create the OpenLayers map
@@ -226,6 +227,13 @@ async function addWmtsLayer() {
       projection: matrixSet.crs,
       dimensions,
     }),
+    // this will limit the rendering to the actual range where data is available
+    maxResolution: tileGrid.getResolutions()[0],
+    extent: transformExtent(
+      layer.latLonBoundingBox,
+      'EPSG:4326',
+      openLayersMap.getView().getProjection()
+    );
   });
   openLayersMap.addLayer(layer);
 }</pre

--- a/src/wmts/endpoint.ts
+++ b/src/wmts/endpoint.ts
@@ -3,10 +3,10 @@ import { setQueryParams } from '../shared/http-utils.js';
 import { useCache } from '../shared/cache.js';
 import { parseWmtsCapabilities } from '../worker/index.js';
 import {
-  WmtsLayerDimensionValue,
-  WmtsLayerResourceLink,
   WmtsEndpointInfo,
   WmtsLayer,
+  WmtsLayerDimensionValue,
+  WmtsLayerResourceLink,
   WmtsMatrixSet,
 } from './model.js';
 import { generateGetTileUrl } from './url.js';
@@ -209,8 +209,12 @@ export default class WmtsEndpoint {
         (matrixSet) => matrixSet.identifier === matrixSetIdentifier
       ) ?? layer.matrixSets[0];
     const matrixSet = this.getMatrixSetByIdentifier(matrixSetLink.identifier);
-    return this.tileGridModule.then(({ buildOpenLayersTileGrid }) =>
-      buildOpenLayersTileGrid(matrixSet, matrixSetLink.limits)
-    );
+    return this.tileGridModule.then((olTileGridModule) => {
+      if (!olTileGridModule) return null;
+      return olTileGridModule.buildOpenLayersTileGrid(
+        matrixSet,
+        matrixSetLink.limits
+      );
+    });
   }
 }


### PR DESCRIPTION
The example now shows how to restrict the WMTS layer using extent and resolution, to avoid querying tiles all across the world.