### PR TITLE
Fix URL manipulation in link-utils

### DIFF
--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -2169,7 +2169,9 @@ The document at http://local/nonexisting?f=json could not be fetched.`
   describe('endpoint with query params', () => {
     describe('on collections path', () => {
       beforeEach(() => {
-        endpoint = new OgcApiEndpoint('http://local/sample-data/collections?foo=bar');
+        endpoint = new OgcApiEndpoint(
+          'http://local/sample-data/collections?foo=bar'
+        );
       });
       it('correctly parses endpoint info and collections', async () => {
         await expect(endpoint.info).resolves.toEqual({
@@ -2201,8 +2203,8 @@ The document at http://local/nonexisting?f=json could not be fetched.`
           'urban_areas',
           'waterlines',
           'woodland',
-        ]);   
+        ]);
       });
     });
-  })
+  });
 });

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -2166,4 +2166,43 @@ The document at http://local/nonexisting?f=json could not be fetched.`
       });
     });
   });
+  describe('endpoint with query params', () => {
+    describe('on collections path', () => {
+      beforeEach(() => {
+        endpoint = new OgcApiEndpoint('http://local/sample-data/collections?foo=bar');
+      });
+      it('correctly parses endpoint info and collections', async () => {
+        await expect(endpoint.info).resolves.toEqual({
+          title: 'OS Open Zoomstack',
+          description:
+            'OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.',
+          attribution:
+            'Contains OS data © Crown copyright and database right 2021.',
+        });
+        await expect(endpoint.featureCollections).resolves.toEqual([
+          'airports',
+          'boundaries',
+          'contours',
+          'district_buildings',
+          'etl',
+          'foreshore',
+          'greenspace',
+          'land',
+          'local_buildings',
+          'names',
+          'national_parks',
+          'rail',
+          'railway_stations',
+          'roads_local',
+          'roads_national',
+          'roads_regional',
+          'sites',
+          'surfacewater',
+          'urban_areas',
+          'waterlines',
+          'woodland',
+        ]);   
+      });
+    });
+  })
 });

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -69,7 +69,11 @@ export function fetchCollectionRoot(
     }
     // if there is a collections array, we expect the parent path to end with slash
     if ('collections' in doc) {
-      parentUrl = `${parentUrl}/`;
+      const urlObj = new URL(parentUrl);
+      if (!urlObj.pathname.endsWith('/')) {
+        urlObj.pathname = `${urlObj.pathname}/`;
+      }
+      parentUrl= urlObj.toString();
     }
     return fetchCollectionRoot(parentUrl);
   });

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -73,7 +73,7 @@ export function fetchCollectionRoot(
       if (!urlObj.pathname.endsWith('/')) {
         urlObj.pathname = `${urlObj.pathname}/`;
       }
-      parentUrl= urlObj.toString();
+      parentUrl = urlObj.toString();
     }
     return fetchCollectionRoot(parentUrl);
   });


### PR DESCRIPTION
This PR fixes the manipulation of a URL. Instead of handling it as a string it will be handled as URL-Object.

This was mentioned here: https://github.com/camptocamp/ogc-client/issues/85