### PR TITLE
datetime-parameter-filtering

### DIFF
--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -1399,6 +1399,75 @@ describe('OgcApiEndpoint', () => {
           },
         ]);
       });
+      describe('parameters encoding', () => {
+        beforeEach(() => {
+          jest.clearAllMocks();
+        });
+        it('encodes parameters in the URL', async () => {
+          await endpoint.getCollectionItems(
+            'roads_national',
+            20,
+            12,
+            false,
+            ['attr1'],
+            [1, 2, 3, 4],
+            ['attr2', 'attr3'],
+            new Date('2023-02-01')
+          );
+          expect(window.fetch).toHaveBeenCalledWith(
+            'https://my.server.org/sample-data/collections/roads_national/items?f=json&limit=20&offset=12&skipGeometry=false&sortby=attr1&bbox=1%2C2%2C3%2C4&properties=attr2%2Cattr3&datetime=2023-02-01T00%3A00%3A00.000Z',
+            { method: 'GET', headers: expect.any(Object) }
+          );
+        });
+        it('encodes date time param as an interval', async () => {
+          await endpoint.getCollectionItems(
+            'roads_national',
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { start: new Date('2023-02-01'), end: new Date('2023-02-15') }
+          );
+          expect(window.fetch).toHaveBeenCalledWith(
+            'https://my.server.org/sample-data/collections/roads_national/items?f=json&limit=10&offset=0&datetime=2023-02-01T00%3A00%3A00.000Z%2F2023-02-15T00%3A00%3A00.000Z',
+            { method: 'GET', headers: expect.any(Object) }
+          );
+        });
+        it('encodes date time param as an interval (start only)', async () => {
+          await endpoint.getCollectionItems(
+            'roads_national',
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { start: new Date('2023-02-01') }
+          );
+          expect(window.fetch).toHaveBeenCalledWith(
+            'https://my.server.org/sample-data/collections/roads_national/items?f=json&limit=10&offset=0&datetime=2023-02-01T00%3A00%3A00.000Z%2F..',
+            { method: 'GET', headers: expect.any(Object) }
+          );
+        });
+        it('encodes date time param as an interval (end only)', async () => {
+          await endpoint.getCollectionItems(
+            'roads_national',
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { end: new Date('2023-02-01') }
+          );
+          expect(window.fetch).toHaveBeenCalledWith(
+            'https://my.server.org/sample-data/collections/roads_national/items?f=json&limit=10&offset=0&datetime=..%2F2023-02-01T00%3A00%3A00.000Z',
+            { method: 'GET', headers: expect.any(Object) }
+          );
+        });
+      });
     });
     describe('#getCollectionItem', () => {
       it('returns one airports collection item', async () => {

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -391,6 +391,21 @@ ${e.message}`);
   }
 
   /**
+   * Determines if the given datetime parameter is valid according to the
+   * [OGC requirement](https://docs.ogc.org/is/17-069r3/17-069r3.html#_parameter_datetime).
+   *
+   * The datetime is valid if it:
+   * - has a `start` OR `end`
+   *
+   * Requirement 25.D
+   * @param datetime
+   * @private
+   */
+  private validateDatetimeParameter(datetime: {start?: Date, end?: Date}): boolean {
+    return datetime.start != undefined || datetime.end != undefined;
+  }
+
+  /**
    * Returns a promise resolving to an array of items from a collection with the given query parameters.
    * @param collectionId
    * @param limit
@@ -399,6 +414,7 @@ ${e.message}`);
    * @param sortby
    * @param bbox
    * @param properties
+   * @param datetime
    */
   getCollectionItems(
     collectionId: string,
@@ -407,7 +423,8 @@ ${e.message}`);
     skipGeometry: boolean = null,
     sortby: string[] = null,
     bbox: [number, number, number, number] = null,
-    properties: string[] = null
+    properties: string[] = null,
+    datetime: {start?: Date, end?: Date} = null
   ): Promise<OgcApiCollectionItem[]> {
     return this.getCollectionDocument(collectionId)
       .then((collectionDoc) => {
@@ -425,6 +442,8 @@ ${e.message}`);
           url.searchParams.set('bbox', bbox.join(',').toString());
         if (properties !== null)
           url.searchParams.set('properties', properties.join(',').toString());
+        if (datetime !== null && this.validateDatetimeParameter(datetime))
+          url.searchParams.set('datetime', `${datetime.start ?? '..'}/${datetime.end ?? '..'}`);
         return url.toString();
       })
       .then(fetchDocument)

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -87,3 +87,9 @@ export type MetadataURL = {
 
 export type FieldName = string;
 export type FieldSort = ['D' | 'A', FieldName];
+
+export type DateTimeParameter =
+  | Date
+  | { start: Date }
+  | { end: Date }
+  | { start: Date; end: Date };


### PR DESCRIPTION
Added optional `datetime` filtering parameter to `getCollections` endpoint function in response to [Issue-90](https://github.com/camptocamp/ogc-client/issues/90)