### PR TITLE
OGC API / Handle the case when the root document is situated at the `/` path

### DIFF
--- a/fixtures/ogc-api/root-path.json
+++ b/fixtures/ogc-api/root-path.json
@@ -1,0 +1,3 @@
+{
+  "hello": "world"
+}

--- a/fixtures/ogc-api/sample-data-root.json
+++ b/fixtures/ogc-api/sample-data-root.json
@@ -1,0 +1,93 @@
+{
+  "title": "OS Open Zoomstack",
+  "description": "OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org?f=html"
+    },
+    {
+      "rel": "conformance",
+      "title": "OGC API conformance classes implemented by this server",
+      "href": "https://my.server.org/conformance"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/conformance",
+      "title": "OGC API conformance classes implemented by this server",
+      "href": "https://my.server.org/conformance"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/styles",
+      "title": "Styles to render the data in maps",
+      "href": "https://my.server.org/styles"
+    },
+    {
+      "rel": "ldp-map",
+      "title": "Access a web map with the data",
+      "href": "https://my.server.org/styles/Road?f=html"
+    },
+    {
+      "rel": "resources",
+      "title": "Resources for rendering the data in maps",
+      "href": "https://my.server.org/resources"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector",
+      "title": "Access the data as tiles",
+      "href": "https://my.server.org/tiles"
+    },
+    {
+      "rel": "service-doc",
+      "type": "text/html",
+      "title": "Documentation of the API",
+      "href": "https://my.server.org/api?f=html"
+    },
+    {
+      "rel": "service-desc",
+      "type": "application/vnd.oai.openapi+json;version=3.0",
+      "title": "Definition of the API in OpenAPI 3.0",
+      "href": "https://my.server.org/api?f=json"
+    },
+    {
+      "rel": "service-desc",
+      "type": "application/vnd.oai.openapi;version=3.0",
+      "title": "Definition of the API in OpenAPI 3.0",
+      "href": "https://my.server.org/api?f=yaml"
+    },
+    {
+      "rel": "data",
+      "title": "Access the data",
+      "href": "https://my.server.org/collections"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/data",
+      "title": "Access the data",
+      "href": "https://my.server.org/collections"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+      "title": "List of tile matrix sets implemented by this API",
+      "href": "https://my.server.org/tileMatrixSets"
+    }
+  ],
+  "attribution": "Contains OS data © Crown copyright and database right 2021.",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -9.23056668252574, 49.81680248396912, 2.69547862504583,
+          60.78388658611872
+        ]
+      ],
+      "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+    }
+  }
+}

--- a/fixtures/ogc-api/sample-data-root/collections.json
+++ b/fixtures/ogc-api/sample-data-root/collections.json
@@ -1,0 +1,1404 @@
+{
+  "title": "OS Open Zoomstack",
+  "description": "OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/collections?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/collections?f=html"
+    },
+    {
+      "rel": "alternate",
+      "type": "application/xml",
+      "title": "This document as XML",
+      "href": "https://my.server.org/collections?f=xml"
+    },
+    {
+      "rel": "license",
+      "title": "Open Government Licence (OGL)",
+      "href": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    },
+    {
+      "rel": "enclosure",
+      "type": "application/geopackage+sqlite3",
+      "title": "OS Open Zoomstack as a GeoPackage",
+      "href": "https://api.os.uk/downloads/v1/products/OpenZoomstack/downloads?area=GB&format=GeoPackage"
+    }
+  ],
+  "crs": [
+    "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "http://www.opengis.net/def/crs/EPSG/0/27700",
+    "http://www.opengis.net/def/crs/EPSG/0/4258",
+    "http://www.opengis.net/def/crs/EPSG/0/4326",
+    "http://www.opengis.net/def/crs/EPSG/0/3857"
+  ],
+  "collections": [
+    {
+      "title": "Airports",
+      "description": "A centre point for all major airports including a name.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Airports' feature collection",
+          "href": "https://my.server.org/collections/airports"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Airports' as JSON-FG",
+          "href": "https://my.server.org/collections/airports/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Airports' as GeoJSON",
+          "href": "https://my.server.org/collections/airports/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Airports' as FlatGeobuf",
+          "href": "https://my.server.org/collections/airports/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Airports' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/airports/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Airports' as HTML",
+          "href": "https://my.server.org/collections/airports/items?f=html"
+        }
+      ],
+      "id": "airports",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -7.942759150065165, 49.901607895996534, 1.9957427933628138,
+              60.133709755754
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 46
+    },
+    {
+      "title": "Boundaries",
+      "description": "National boundary lines between England - Scotland and England - Wales.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Boundaries' feature collection",
+          "href": "https://my.server.org/collections/boundaries"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Boundaries' as JSON-FG",
+          "href": "https://my.server.org/collections/boundaries/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Boundaries' as GeoJSON",
+          "href": "https://my.server.org/collections/boundaries/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Boundaries' as FlatGeobuf",
+          "href": "https://my.server.org/collections/boundaries/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Boundaries' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/boundaries/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Boundaries' as HTML",
+          "href": "https://my.server.org/collections/boundaries/items?f=html"
+        }
+      ],
+      "id": "boundaries",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -3.353443758684184, 51.56539937427431, -2.030006856546504,
+              55.81167771035611
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 32
+    },
+    {
+      "title": "Contours",
+      "description": "These contours lines have a 10-metre interval with an index every 50 metres. Each contour contains a value.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Contours' feature collection",
+          "href": "https://my.server.org/collections/contours"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Contours' as JSON-FG",
+          "href": "https://my.server.org/collections/contours/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Contours' as GeoJSON",
+          "href": "https://my.server.org/collections/contours/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Contours' as FlatGeobuf",
+          "href": "https://my.server.org/collections/contours/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Contours' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/contours/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Contours' as HTML",
+          "href": "https://my.server.org/collections/contours/items?f=html"
+        }
+      ],
+      "id": "contours",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.229436317495699, 49.82026221571111, 2.6868283140378657,
+              60.77919884922387
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 952689
+    },
+    {
+      "title": "District Buildings",
+      "description": "Generalised building footprints at district resolution.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'District Buildings' feature collection",
+          "href": "https://my.server.org/collections/district_buildings"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'District Buildings' as JSON-FG",
+          "href": "https://my.server.org/collections/district_buildings/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'District Buildings' as GeoJSON",
+          "href": "https://my.server.org/collections/district_buildings/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'District Buildings' as FlatGeobuf",
+          "href": "https://my.server.org/collections/district_buildings/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'District Buildings' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/district_buildings/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'District Buildings' as HTML",
+          "href": "https://my.server.org/collections/district_buildings/items?f=html"
+        }
+      ],
+      "id": "district_buildings",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.161386312800703, 49.83051579969082, 2.6926347822219707,
+              60.77807759733313
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 2756155
+    },
+    {
+      "title": "ETL",
+      "description": "Electricity Transmission Lines.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'ETL' feature collection",
+          "href": "https://my.server.org/collections/etl"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'ETL' as JSON-FG",
+          "href": "https://my.server.org/collections/etl/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'ETL' as GeoJSON",
+          "href": "https://my.server.org/collections/etl/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'ETL' as FlatGeobuf",
+          "href": "https://my.server.org/collections/etl/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'ETL' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/etl/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'ETL' as HTML",
+          "href": "https://my.server.org/collections/etl/items?f=html"
+        }
+      ],
+      "id": "etl",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -6.289748340048653, 50.14037477109227, 2.33600775696539,
+              58.515541995093926
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 3456
+    },
+    {
+      "title": "Foreshore",
+      "description": "These polygons depict the part of the shore or beach which lies between the Mean Low Water Mark and Mean High Water Mark.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Foreshore' feature collection",
+          "href": "https://my.server.org/collections/foreshore"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Foreshore' as JSON-FG",
+          "href": "https://my.server.org/collections/foreshore/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Foreshore' as GeoJSON",
+          "href": "https://my.server.org/collections/foreshore/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Foreshore' as FlatGeobuf",
+          "href": "https://my.server.org/collections/foreshore/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Foreshore' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/foreshore/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Foreshore' as HTML",
+          "href": "https://my.server.org/collections/foreshore/items?f=html"
+        }
+      ],
+      "id": "foreshore",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.229007463313069, 49.81685890446522, 2.69547862504583,
+              60.783438341201155
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 36931
+    },
+    {
+      "title": "Greenspace",
+      "description": "Polygon features representing the extent of places such as parks and sports facilities that are likely to be accessible to the public.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Greenspace' feature collection",
+          "href": "https://my.server.org/collections/greenspace"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Greenspace' as JSON-FG",
+          "href": "https://my.server.org/collections/greenspace/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Greenspace' as GeoJSON",
+          "href": "https://my.server.org/collections/greenspace/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Greenspace' as FlatGeobuf",
+          "href": "https://my.server.org/collections/greenspace/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Greenspace' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/greenspace/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Greenspace' as HTML",
+          "href": "https://my.server.org/collections/greenspace/items?f=html"
+        }
+      ],
+      "id": "greenspace",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.140209405918318, 49.847346158649266, 2.6798173070292117,
+              60.72844339242528
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 163772
+    },
+    {
+      "title": "Land",
+      "description": "This layer depicts the shape of Great Britain.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Land' feature collection",
+          "href": "https://my.server.org/collections/land"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Land' as JSON-FG",
+          "href": "https://my.server.org/collections/land/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Land' as GeoJSON",
+          "href": "https://my.server.org/collections/land/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Land' as FlatGeobuf",
+          "href": "https://my.server.org/collections/land/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Land' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/land/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Land' as HTML",
+          "href": "https://my.server.org/collections/land/items?f=html"
+        }
+      ],
+      "id": "land",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.230549516889134, 49.81687027180851, 2.6954553633653067,
+              60.78336234918871
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 47845
+    },
+    {
+      "title": "Local Buildings",
+      "description": "Generalised building footprints at local resolution. The buildings have a unique identifier which can be used to style features distinctly. The identifier will not be persistent between product versions and therefore there will be no change history information for a feature.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Local Buildings' feature collection",
+          "href": "https://my.server.org/collections/local_buildings"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Local Buildings' as JSON-FG",
+          "href": "https://my.server.org/collections/local_buildings/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Local Buildings' as GeoJSON",
+          "href": "https://my.server.org/collections/local_buildings/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Local Buildings' as FlatGeobuf",
+          "href": "https://my.server.org/collections/local_buildings/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Local Buildings' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/local_buildings/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Local Buildings' as HTML",
+          "href": "https://my.server.org/collections/local_buildings/items?f=html"
+        }
+      ],
+      "id": "local_buildings",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.161552750416005, 49.84423409871862, 2.693061112022058,
+              60.77806491151261
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 14767492
+    },
+    {
+      "title": "Names",
+      "description": "Use this point layer to render contextual labels on your map.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Names' feature collection",
+          "href": "https://my.server.org/collections/names"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Names' as JSON-FG",
+          "href": "https://my.server.org/collections/names/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Names' as GeoJSON",
+          "href": "https://my.server.org/collections/names/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Names' as FlatGeobuf",
+          "href": "https://my.server.org/collections/names/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Names' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/names/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Names' as HTML",
+          "href": "https://my.server.org/collections/names/items?f=html"
+        }
+      ],
+      "id": "names",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.223028104021813, 49.8211736840672, 2.6872590240033913,
+              60.77819537105956
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 663624
+    },
+    {
+      "title": "National Parks",
+      "description": "Theses polygons depict the extent of the 15 National Parks in Great Britain.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'National Parks' feature collection",
+          "href": "https://my.server.org/collections/national_parks"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'National Parks' as JSON-FG",
+          "href": "https://my.server.org/collections/national_parks/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'National Parks' as GeoJSON",
+          "href": "https://my.server.org/collections/national_parks/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'National Parks' as FlatGeobuf",
+          "href": "https://my.server.org/collections/national_parks/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'National Parks' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/national_parks/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'National Parks' as HTML",
+          "href": "https://my.server.org/collections/national_parks/items?f=html"
+        }
+      ],
+      "id": "national_parks",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -6.000951880798203, 50.350225515433486, 2.197829108619243,
+              57.35677547861099
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 39
+    },
+    {
+      "title": "Rail",
+      "description": "Lines representing the railway network. They are broken where they pass under bridges, buildings or other obstructing detail.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Rail' feature collection",
+          "href": "https://my.server.org/collections/rail"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Rail' as JSON-FG",
+          "href": "https://my.server.org/collections/rail/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Rail' as GeoJSON",
+          "href": "https://my.server.org/collections/rail/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Rail' as FlatGeobuf",
+          "href": "https://my.server.org/collections/rail/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Rail' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/rail/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Rail' as HTML",
+          "href": "https://my.server.org/collections/rail/items?f=html"
+        }
+      ],
+      "id": "rail",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -6.57793449730909, 50.11274051097212, 2.616645763341211,
+              60.35171925328691
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 105582
+    },
+    {
+      "title": "Railway Stations",
+      "description": "This layer contains a point for all stations and includes a name.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Railway Stations' feature collection",
+          "href": "https://my.server.org/collections/railway_stations"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Railway Stations' as JSON-FG",
+          "href": "https://my.server.org/collections/railway_stations/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Railway Stations' as GeoJSON",
+          "href": "https://my.server.org/collections/railway_stations/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Railway Stations' as FlatGeobuf",
+          "href": "https://my.server.org/collections/railway_stations/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Railway Stations' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/railway_stations/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Railway Stations' as HTML",
+          "href": "https://my.server.org/collections/railway_stations/items?f=html"
+        }
+      ],
+      "id": "railway_stations",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -6.336940205377114, 50.11281330079447, 2.373901529064454,
+              58.525818197436486
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 3473
+    },
+    {
+      "title": "Local Roads",
+      "description": "Lines representing the road network. A road is defined as a metalled way for vehicles.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Local Roads' feature collection",
+          "href": "https://my.server.org/collections/roads_local"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Local Roads' as JSON-FG",
+          "href": "https://my.server.org/collections/roads_local/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Local Roads' as GeoJSON",
+          "href": "https://my.server.org/collections/roads_local/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Local Roads' as FlatGeobuf",
+          "href": "https://my.server.org/collections/roads_local/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Local Roads' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/roads_local/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Local Roads' as HTML",
+          "href": "https://my.server.org/collections/roads_local/items?f=html"
+        }
+      ],
+      "id": "roads_local",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.157833237161705, 49.844845328102735, 2.6891998217837148,
+              60.75074152255422
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 3179639
+    },
+    {
+      "title": "National Roads",
+      "description": "Lines representing the road network. A road is defined as a metalled way for vehicles.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'National Roads' feature collection",
+          "href": "https://my.server.org/collections/roads_national"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'National Roads' as JSON-FG",
+          "href": "https://my.server.org/collections/roads_national/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'National Roads' as GeoJSON",
+          "href": "https://my.server.org/collections/roads_national/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'National Roads' as FlatGeobuf",
+          "href": "https://my.server.org/collections/roads_national/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'National Roads' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/roads_national/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'National Roads' as HTML",
+          "href": "https://my.server.org/collections/roads_national/items?f=html"
+        }
+      ],
+      "id": "roads_national",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -6.4956758012099645, 50.08021976237488, 2.383883951687144,
+              58.54688148276149
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 123905
+    },
+    {
+      "title": "Regional Roads",
+      "description": "Lines representing the road network. A road is defined as a metalled way for vehicles.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Regional Roads' feature collection",
+          "href": "https://my.server.org/collections/roads_regional"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Regional Roads' as JSON-FG",
+          "href": "https://my.server.org/collections/roads_regional/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Regional Roads' as GeoJSON",
+          "href": "https://my.server.org/collections/roads_regional/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Regional Roads' as FlatGeobuf",
+          "href": "https://my.server.org/collections/roads_regional/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Regional Roads' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/roads_regional/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Regional Roads' as HTML",
+          "href": "https://my.server.org/collections/roads_regional/items?f=html"
+        }
+      ],
+      "id": "roads_regional",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -8.140045163468065, 49.897828949470515, 2.678925679725326,
+              60.72856279715021
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 342709
+    },
+    {
+      "title": "Sites",
+      "description": "Polygon features that represent the area or extent of certain types of function or activity.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Sites' feature collection",
+          "href": "https://my.server.org/collections/sites"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Sites' as JSON-FG",
+          "href": "https://my.server.org/collections/sites/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Sites' as GeoJSON",
+          "href": "https://my.server.org/collections/sites/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Sites' as FlatGeobuf",
+          "href": "https://my.server.org/collections/sites/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Sites' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/sites/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Sites' as HTML",
+          "href": "https://my.server.org/collections/sites/items?f=html"
+        }
+      ],
+      "id": "sites",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -8.114938143586947, 49.88033059118879, 2.6783629940894356,
+              60.68320893890659
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 36163
+    },
+    {
+      "title": "Surface Water",
+      "description": "These polygons represent inland water bodies that are sufficiently wide enough to be captured as an area.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Surface Water' feature collection",
+          "href": "https://my.server.org/collections/surfacewater"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Surface Water' as JSON-FG",
+          "href": "https://my.server.org/collections/surfacewater/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Surface Water' as GeoJSON",
+          "href": "https://my.server.org/collections/surfacewater/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Surface Water' as FlatGeobuf",
+          "href": "https://my.server.org/collections/surfacewater/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Surface Water' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/surfacewater/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Surface Water' as HTML",
+          "href": "https://my.server.org/collections/surfacewater/items?f=html"
+        }
+      ],
+      "id": "surfacewater",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.149150953572926, 49.849552493410215, 2.6791066928139706,
+              60.78388658611872
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 520687
+    },
+    {
+      "title": "Urban Areas",
+      "description": "These are generalised polygons representing built-up areas for use at smaller scales.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Urban Areas' feature collection",
+          "href": "https://my.server.org/collections/urban_areas"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Urban Areas' as JSON-FG",
+          "href": "https://my.server.org/collections/urban_areas/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Urban Areas' as GeoJSON",
+          "href": "https://my.server.org/collections/urban_areas/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Urban Areas' as FlatGeobuf",
+          "href": "https://my.server.org/collections/urban_areas/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Urban Areas' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/urban_areas/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Urban Areas' as HTML",
+          "href": "https://my.server.org/collections/urban_areas/items?f=html"
+        }
+      ],
+      "id": "urban_areas",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -8.053765984889685, 49.89774857169156, 2.6293155160795716,
+              60.3210966112084
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 5499
+    },
+    {
+      "title": "Waterlines",
+      "description": "Lines representing rivers, canals, drains and other linear bodies of water.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Waterlines' feature collection",
+          "href": "https://my.server.org/collections/waterlines"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Waterlines' as JSON-FG",
+          "href": "https://my.server.org/collections/waterlines/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Waterlines' as GeoJSON",
+          "href": "https://my.server.org/collections/waterlines/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Waterlines' as FlatGeobuf",
+          "href": "https://my.server.org/collections/waterlines/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Waterlines' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/waterlines/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Waterlines' as HTML",
+          "href": "https://my.server.org/collections/waterlines/items?f=html"
+        }
+      ],
+      "id": "waterlines",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -9.23056668252574, 49.81680248396912, 2.69547862504583,
+              60.783438341201155
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 2503541
+    },
+    {
+      "title": "Woodland",
+      "description": "The polygons represent areas of trees: coniferous, non-coniferous and mixed.",
+      "links": [
+        {
+          "rel": "self",
+          "title": "The 'Woodland' feature collection",
+          "href": "https://my.server.org/collections/woodland"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json",
+          "title": "Access the features in the collection 'Woodland' as JSON-FG",
+          "href": "https://my.server.org/collections/woodland/items?f=jsonfg"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "title": "Access the features in the collection 'Woodland' as GeoJSON",
+          "href": "https://my.server.org/collections/woodland/items?f=json"
+        },
+        {
+          "rel": "items",
+          "type": "application/flatgeobuf",
+          "title": "Access the features in the collection 'Woodland' as FlatGeobuf",
+          "href": "https://my.server.org/collections/woodland/items?f=fgb"
+        },
+        {
+          "rel": "items",
+          "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+          "title": "Access the features in the collection 'Woodland' as JSON-FG (GeoJSON Compatibility Mode)",
+          "href": "https://my.server.org/collections/woodland/items?f=jsonfgc"
+        },
+        {
+          "rel": "items",
+          "type": "text/html",
+          "title": "Access the features in the collection 'Woodland' as HTML",
+          "href": "https://my.server.org/collections/woodland/items?f=html"
+        }
+      ],
+      "id": "woodland",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              -8.115229230492005, 49.87727148846909, 2.67341949373892,
+              60.687673069835824
+            ]
+          ],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "feature",
+      "crs": ["#/crs"],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+      "itemCount": 1285805
+    },
+    {
+      "id": "dutch-metadata",
+      "title": "Sample metadata records from Dutch Nationaal georegister",
+      "description": "Sample metadata records from Dutch Nationaal georegister",
+      "keywords": ["netherlands", "open data", "georegister"],
+      "links": [
+        {
+          "type": "text/html",
+          "rel": "canonical",
+          "title": "information",
+          "href": "https://www.nationaalgeoregister.nl",
+          "hreflang": "nl-NL"
+        },
+        {
+          "type": "application/json",
+          "rel": "root",
+          "title": "The landing page of this server as JSON",
+          "href": "https://my.server.org?f=json"
+        },
+        {
+          "type": "text/html",
+          "rel": "root",
+          "title": "The landing page of this server as HTML",
+          "href": "https://my.server.org?f=html"
+        },
+        {
+          "type": "application/json",
+          "rel": "self",
+          "title": "This document as JSON",
+          "href": "https://my.server.org/collections/dutch-metadata?f=json"
+        },
+        {
+          "type": "application/ld+json",
+          "rel": "alternate",
+          "title": "This document as RDF (JSON-LD)",
+          "href": "https://my.server.org/collections/dutch-metadata?f=jsonld"
+        },
+        {
+          "type": "text/html",
+          "rel": "alternate",
+          "title": "This document as HTML",
+          "href": "https://my.server.org/collections/dutch-metadata?f=html"
+        },
+        {
+          "type": "application/json",
+          "rel": "queryables",
+          "title": "Queryables for this collection as JSON",
+          "href": "https://my.server.org/collections/dutch-metadata/queryables?f=json"
+        },
+        {
+          "type": "text/html",
+          "rel": "queryables",
+          "title": "Queryables for this collection as HTML",
+          "href": "https://my.server.org/collections/dutch-metadata/queryables?f=html"
+        },
+        {
+          "type": "application/geo+json",
+          "rel": "items",
+          "title": "items as GeoJSON",
+          "href": "https://my.server.org/collections/dutch-metadata/items?f=json"
+        },
+        {
+          "type": "application/ld+json",
+          "rel": "items",
+          "title": "items as RDF (GeoJSON-LD)",
+          "href": "https://my.server.org/collections/dutch-metadata/items?f=jsonld"
+        },
+        {
+          "type": "text/html",
+          "rel": "items",
+          "title": "Items as HTML",
+          "href": "https://my.server.org/collections/dutch-metadata/items?f=html"
+        }
+      ],
+      "extent": {
+        "spatial": {
+          "bbox": [[3.37, 50.75, 7.21, 53.47]],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      },
+      "itemType": "record"
+    },
+    {
+      "id": "missing-feature-type-metadata",
+      "title": "Sample metadata records that is missing featureType",
+      "description": "Sample metadata records that is missing featureType",
+      "keywords": ["netherlands", "open data", "georegister"],
+      "links": [
+        {
+          "type": "text/html",
+          "rel": "canonical",
+          "title": "information",
+          "href": "https://www.nationaalgeoregister.nl",
+          "hreflang": "nl-NL"
+        },
+        {
+          "type": "application/json",
+          "rel": "root",
+          "title": "The landing page of this server as JSON",
+          "href": "https://my.server.org?f=json"
+        },
+        {
+          "type": "text/html",
+          "rel": "root",
+          "title": "The landing page of this server as HTML",
+          "href": "https://my.server.org?f=html"
+        },
+        {
+          "type": "application/json",
+          "rel": "self",
+          "title": "This document as JSON",
+          "href": "https://my.server.org/collections/missing-feature-type-metadata?f=json"
+        },
+        {
+          "type": "application/ld+json",
+          "rel": "alternate",
+          "title": "This document as RDF (JSON-LD)",
+          "href": "https://my.server.org/collections/missing-feature-type-metadata?f=jsonld"
+        },
+        {
+          "type": "text/html",
+          "rel": "alternate",
+          "title": "This document as HTML",
+          "href": "https://my.server.org/collections/missing-feature-type-metadata?f=html"
+        },
+        {
+          "type": "application/json",
+          "rel": "queryables",
+          "title": "Queryables for this collection as JSON",
+          "href": "https://my.server.org/collections/missing-feature-type-metadata/queryables?f=json"
+        },
+        {
+          "type": "text/html",
+          "rel": "queryables",
+          "title": "Queryables for this collection as HTML",
+          "href": "https://my.server.org/collections/missing-feature-type-metadata/queryables?f=html"
+        },
+        {
+          "type": "application/geo+json",
+          "rel": "items",
+          "title": "items as GeoJSON",
+          "href": "https://my.server.org/collections/missing-feature-type-metadata/items?f=json"
+        },
+        {
+          "type": "application/ld+json",
+          "rel": "items",
+          "title": "items as RDF (GeoJSON-LD)",
+          "href": "https://my.server.org/collections/missing-feature-type-metadata/items?f=jsonld"
+        },
+        {
+          "type": "text/html",
+          "rel": "items",
+          "title": "Items as HTML",
+          "href": "https://my.server.org/collections/missing-feature-type-metadata/items?f=html"
+        }
+      ],
+      "extent": {
+        "spatial": {
+          "bbox": [[3.37, 50.75, 7.21, 53.47]],
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        }
+      }
+    }
+  ]
+}

--- a/fixtures/ogc-api/sample-data-root/collections/airports.json
+++ b/fixtures/ogc-api/sample-data-root/collections/airports.json
@@ -1,0 +1,111 @@
+{
+  "title": "Airports",
+  "description": "A centre point for all major airports including a name.",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/collections/airports?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/collections/airports?f=html"
+    },
+    {
+      "rel": "alternate",
+      "type": "application/xml",
+      "title": "This document as XML",
+      "href": "https://my.server.org/collections/airports?f=xml"
+    },
+    {
+      "rel": "license",
+      "title": "Open Government Licence (OGL)",
+      "href": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+      "title": "Queryable attributes",
+      "href": "https://my.server.org/collections/airports/queryables"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/sortables",
+      "title": "Sortable attributes",
+      "href": "https://my.server.org/collections/airports/sortables"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/0.0/schema-item",
+      "title": "Schema of features in 'Airports'",
+      "href": "https://my.server.org/collections/airports/schemas/feature"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/0.0/schema-collection",
+      "title": "Schema of feature collections in 'Airports'",
+      "href": "https://my.server.org/collections/airports/schemas/collection"
+    },
+    {
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/styles",
+      "title": "Styles to render the data in maps",
+      "href": "https://my.server.org/collections/airports/styles"
+    },
+    {
+      "rel": "ldp-map",
+      "title": "Access a web map with the data",
+      "href": "https://my.server.org/collections/airports/styles/Road?f=html"
+    },
+    {
+      "rel": "items",
+      "type": "text/html",
+      "title": "Access the features in the collection 'Airports' as HTML",
+      "href": "https://my.server.org/collections/airports/items?f=html"
+    },
+    {
+      "rel": "items",
+      "type": "application/vnd.ogc.fg+json",
+      "title": "Access the features in the collection 'Airports' as JSON-FG",
+      "href": "https://my.server.org/collections/airports/items?f=jsonfg"
+    },
+    {
+      "rel": "items",
+      "type": "application/geo+json",
+      "title": "Access the features in the collection 'Airports' as GeoJSON",
+      "href": "https://my.server.org/collections/airports/items?f=json"
+    },
+    {
+      "rel": "items",
+      "type": "application/flatgeobuf",
+      "title": "Access the features in the collection 'Airports' as FlatGeobuf",
+      "href": "https://my.server.org/collections/airports/items?f=fgb"
+    },
+    {
+      "rel": "items",
+      "type": "application/vnd.ogc.fg+json;compatibility=geojson",
+      "title": "Access the features in the collection 'Airports' as JSON-FG (GeoJSON Compatibility Mode)",
+      "href": "https://my.server.org/collections/airports/items?f=jsonfgc"
+    }
+  ],
+  "id": "airports",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -7.942759150065165, 49.901607895996534, 1.9957427933628138,
+          60.133709755754
+        ]
+      ],
+      "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+    }
+  },
+  "itemType": "feature",
+  "crs": [
+    "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "http://www.opengis.net/def/crs/EPSG/0/27700",
+    "http://www.opengis.net/def/crs/EPSG/0/4258",
+    "http://www.opengis.net/def/crs/EPSG/0/4326",
+    "http://www.opengis.net/def/crs/EPSG/0/3857"
+  ],
+  "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/27700",
+  "itemCount": 46
+}

--- a/fixtures/ogc-api/sample-data-root/conformance.json
+++ b/fixtures/ogc-api/sample-data-root/conformance.json
@@ -1,0 +1,62 @@
+{
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document",
+      "href": "https://my.server.org/conformance?f=json"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://my.server.org/conformance?f=html"
+    }
+  ],
+  "conformsTo": [
+    "http://www.opengis.net/spec/cql2/0.0/conf/advanced-comparison-operators",
+    "http://www.opengis.net/spec/cql2/0.0/conf/array-operators",
+    "http://www.opengis.net/spec/cql2/0.0/conf/basic-cql2",
+    "http://www.opengis.net/spec/cql2/0.0/conf/basic-spatial-operators",
+    "http://www.opengis.net/spec/cql2/0.0/conf/case-insensitive-comparison",
+    "http://www.opengis.net/spec/cql2/0.0/conf/cql2-json",
+    "http://www.opengis.net/spec/cql2/0.0/conf/cql2-text",
+    "http://www.opengis.net/spec/cql2/0.0/conf/property-property",
+    "http://www.opengis.net/spec/cql2/0.0/conf/spatial-operators",
+    "http://www.opengis.net/spec/cql2/0.0/conf/temporal-operators",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/html",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json",
+    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+    "http://www.opengis.net/spec/ogcapi-common-2/0.0/conf/collections",
+    "http://www.opengis.net/spec/ogcapi-common-2/0.0/conf/html",
+    "http://www.opengis.net/spec/ogcapi-common-2/0.0/conf/json",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
+    "http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs",
+    "http://www.opengis.net/spec/ogcapi-features-3/0.0/conf/features-filter",
+    "http://www.opengis.net/spec/ogcapi-features-3/0.0/conf/filter",
+    "http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/manage-styles",
+    "http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/mapbox-styles",
+    "http://www.opengis.net/spec/ogcapi-styles-1/0.0/conf/sld-10",
+    "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/dataset-tilesets",
+    "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt",
+    "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset",
+    "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list",
+    "http://www.opengis.net/spec/tms/2.0/conf/json-tilematrixset",
+    "http://www.opengis.net/spec/tms/2.0/conf/json-tilematrixsetlimits",
+    "http://www.opengis.net/spec/tms/2.0/conf/json-tilesetmetadata",
+    "http://www.opengis.net/spec/tms/2.0/conf/tilematrixset",
+    "http://www.opengis.net/spec/tms/2.0/conf/tilematrixsetlimits",
+    "http://www.opengis.net/spec/tms/2.0/conf/tilesetmetadata",
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/html",
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/json",
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/opensearch",
+    "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/sorting"
+  ]
+}

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -1691,65 +1691,69 @@ The document at http://local/sample-data/notjson?f=json does not appear to be va
         ]);
       });
     });
-  });
-  describe('on a single collection path', () => {
-    beforeEach(() => {
-      endpoint = new OgcApiEndpoint(
-        'http://local/sample-data/collections/airports'
-      );
-    });
-    it('correctly parses endpoint info, keep a single collection', async () => {
-      await expect(endpoint.info).resolves.toEqual({
-        title: 'OS Open Zoomstack',
-        description:
-          'OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.',
-        attribution:
-          'Contains OS data © Crown copyright and database right 2021.',
+    describe('on a single collection path', () => {
+      beforeEach(() => {
+        endpoint = new OgcApiEndpoint(
+          'http://local/sample-data/collections/airports'
+        );
       });
-      await expect(endpoint.featureCollections).resolves.toEqual(['airports']);
-    });
-  });
-  describe('on a single collection items path', () => {
-    beforeEach(() => {
-      endpoint = new OgcApiEndpoint(
-        'http://local/sample-data/collections/airports/items'
-      );
-    });
-    it('correctly parses endpoint info, keep a single collection', async () => {
-      await expect(endpoint.info).resolves.toEqual({
-        title: 'OS Open Zoomstack',
-        description:
-          'OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.',
-        attribution:
-          'Contains OS data © Crown copyright and database right 2021.',
+      it('correctly parses endpoint info, keep a single collection', async () => {
+        await expect(endpoint.info).resolves.toEqual({
+          title: 'OS Open Zoomstack',
+          description:
+            'OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.',
+          attribution:
+            'Contains OS data © Crown copyright and database right 2021.',
+        });
+        await expect(endpoint.featureCollections).resolves.toEqual([
+          'airports',
+        ]);
       });
-      await expect(endpoint.featureCollections).resolves.toEqual(['airports']);
     });
-  });
-  describe('on a JSON document which is not part of a valid endpoint', () => {
-    beforeEach(() => {
-      endpoint = new OgcApiEndpoint('http://local/invalid/');
+    describe('on a single collection items path', () => {
+      beforeEach(() => {
+        endpoint = new OgcApiEndpoint(
+          'http://local/sample-data/collections/airports/items'
+        );
+      });
+      it('correctly parses endpoint info, keep a single collection', async () => {
+        await expect(endpoint.info).resolves.toEqual({
+          title: 'OS Open Zoomstack',
+          description:
+            'OS Open Zoomstack is a comprehensive vector basemap showing coverage of Great Britain at a national level, right down to street-level detail.',
+          attribution:
+            'Contains OS data © Crown copyright and database right 2021.',
+        });
+        await expect(endpoint.featureCollections).resolves.toEqual([
+          'airports',
+        ]);
+      });
     });
-    it('throws an explicit error', async () => {
-      await expect(endpoint.info).rejects.toEqual(
-        new EndpointError(
-          `The endpoint appears non-conforming, the following error was encountered:
+    describe('on a JSON document which is not part of a valid endpoint', () => {
+      beforeEach(() => {
+        endpoint = new OgcApiEndpoint('http://local/invalid/');
+      });
+      it('throws an explicit error', async () => {
+        await expect(endpoint.info).rejects.toEqual(
+          new EndpointError(
+            `The endpoint appears non-conforming, the following error was encountered:
 Could not find a root JSON document containing both a link with rel='data' and a link with rel='conformance'.`
-        )
-      );
+          )
+        );
+      });
     });
-  });
-  describe('on a non-existing link', () => {
-    beforeEach(() => {
-      endpoint = new OgcApiEndpoint('http://local/nonexisting');
-    });
-    it('throws an explicit error', async () => {
-      await expect(endpoint.info).rejects.toEqual(
-        new EndpointError(
-          `The endpoint appears non-conforming, the following error was encountered:
+    describe('on a non-existing link', () => {
+      beforeEach(() => {
+        endpoint = new OgcApiEndpoint('http://local/nonexisting');
+      });
+      it('throws an explicit error', async () => {
+        await expect(endpoint.info).rejects.toEqual(
+          new EndpointError(
+            `The endpoint appears non-conforming, the following error was encountered:
 The document at http://local/nonexisting?f=json could not be fetched.`
-        )
-      );
+          )
+        );
+      });
     });
   });
 

--- a/src/ogc-api/endpoint.spec.ts
+++ b/src/ogc-api/endpoint.spec.ts
@@ -28,7 +28,10 @@ beforeAll(() => {
       } as Response;
     }
 
-    const queryPath = url.pathname.replace(/\/$/, ''); // remove trailing slash
+    let queryPath = url.pathname.replace(/\/$/, ''); // remove trailing slash
+    if (queryPath === '') {
+      queryPath = 'root-path'; // make sure we're serving something at the root
+    }
     const format = url.searchParams.get('f') || 'html';
     const filePath = `${path.join(FIXTURES_ROOT, queryPath)}.${format}`;
     try {

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -33,17 +33,11 @@ export function fetchRoot(url: string): Promise<OgcApiDocument> {
         'http://www.opengis.net/def/rel/ogc/1.0/conformance',
       ])
     ) {
-      let parentUrl = getParentPath(url);
+      const parentUrl = getParentPath(url);
       if (!parentUrl) {
         throw new Error(
           `Could not find a root JSON document containing both a link with rel='data' and a link with rel='conformance'.`
         );
-      }
-      // if there is a collections array, we expect the parent path to end with slash
-      if ('collections' in doc) {
-        const urlObj = new URL(parentUrl);
-        urlObj.pathname = `${urlObj.pathname}/`;
-        parentUrl = urlObj.toString();
       }
       return fetchRoot(parentUrl);
     }

--- a/src/shared/url-utils.spec.ts
+++ b/src/shared/url-utils.spec.ts
@@ -8,22 +8,38 @@ describe('link utils', () => {
     it('should return null if parent path is /', () => {
       expect(getParentPath('http://example.com/foo')).toBeNull();
     });
+    it('should return root path correctly if a trailing slash is present', () => {
+      expect(getParentPath('http://example.com/foo/')).toBe(
+        'http://example.com/'
+      );
+    });
     it('should return the parent path', () => {
+      expect(getParentPath('http://example.com/foo/bar/baz')).toBe(
+        'http://example.com/foo/bar'
+      );
+    });
+    it('should return the parent path (including a trailing slash if on the app context part', () => {
       expect(getParentPath('http://example.com/foo/bar')).toBe(
-        'http://example.com/foo'
+        'http://example.com/foo/'
       );
     });
     it('should ignore a trailing slash', () => {
-      expect(getParentPath('http://example.com/foo/bar/')).toBe(
-        'http://example.com/foo'
+      expect(getParentPath('http://example.com/foo/bar/baz/')).toBe(
+        'http://example.com/foo/bar'
       );
     });
     it('should keep query params', () => {
       expect(getParentPath('http://example.com/foo/bar?aa=bb')).toBe(
-        'http://example.com/foo?aa=bb'
+        'http://example.com/foo/?aa=bb'
       );
       expect(getParentPath('http://example.com/foo/bar?')).toBe(
-        'http://example.com/foo?'
+        'http://example.com/foo/?'
+      );
+      expect(getParentPath('http://example.com/foo/bar/baz?aa=bb')).toBe(
+        'http://example.com/foo/bar?aa=bb'
+      );
+      expect(getParentPath('http://example.com/foo/bar/baz?')).toBe(
+        'http://example.com/foo/bar?'
       );
     });
   });

--- a/src/shared/url-utils.ts
+++ b/src/shared/url-utils.ts
@@ -3,10 +3,19 @@
  */
 export function getParentPath(url: string): string | null {
   const urlObj = new URL(url, window.location.toString());
-  const pathParts = urlObj.pathname.replace(/\/$/, '').split('/');
+  let pathParts = urlObj.pathname.split('/');
   if (pathParts.length <= 2) {
+    // cannot go further up
     return null;
   }
-  urlObj.pathname = pathParts.slice(0, -1).join('/');
+  if (pathParts[pathParts.length - 1] === '') {
+    pathParts = pathParts.slice(0, -1); // remove trailing slash if present
+  }
+  pathParts = pathParts.slice(0, -1); // remove last part to go one level up
+  if (pathParts.length === 2 && pathParts[1] !== '') {
+    // push a trailing slash if we're on the "app context" part of the url
+    pathParts.push('');
+  }
+  urlObj.pathname = pathParts.join('/');
   return urlObj.toString();
 }


### PR DESCRIPTION
This is required for this service to be parsed:

https://ogcapi.bgs.ac.uk/collections

https://ogcapi.bgs.ac.uk/collections/scanned-maps-1m

https://ogcapi.bgs.ac.uk/collections/scanned-maps-1m/items