### PR TITLE
Fix error when reading an OGC API endpoint provided by QGIS

### DIFF
--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -45,6 +45,7 @@ import {
   isMimeTypeJson,
   isMimeTypeJsonFg,
 } from '../shared/mime-type.js';
+import { getChildPath } from '../shared/url-utils.js';
 
 /**
  * Represents an OGC API endpoint advertising various collections and services.
@@ -273,7 +274,9 @@ ${e.message}`);
           return fetchLink(collection, 'self', this.baseUrl);
         }
         // otherwise build a URL for the collection
-        return fetchDocument(`${await this.collectionsUrl}/${collectionId}`);
+        return fetchDocument(
+          getChildPath(await this.collectionsUrl, collectionId)
+        );
       });
   }
 

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -365,27 +365,29 @@ ${e.message}`);
     const firstTilesetVector = tilesetsVector[0];
     let vectorTileFormats = [];
     if (firstTilesetVector) {
-      const tilesetUrl = getLinkUrl(firstTilesetVector, 'self', this.baseUrl);
-      if (!tilesetUrl) {
-        throw new Error('No links found for the tileset');
-      }
+      const tilesetUrl = getLinkUrl(
+        firstTilesetVector,
+        'self',
+        this.baseUrl,
+        undefined,
+        true
+      );
       const tilesetDoc = await fetchDocument(tilesetUrl);
-      vectorTileFormats = tilesetDoc.links
-        .filter((link) => link.rel === 'item')
-        .map((link) => link.type);
+      vectorTileFormats = getLinks(tilesetDoc, 'item').map((link) => link.type);
     }
 
     const firstTilesetMap = tilesetsMap[0];
     let mapTileFormats = [];
     if (firstTilesetMap) {
-      const tilesetUrl = getLinkUrl(firstTilesetMap, 'self', this.baseUrl);
-      if (!tilesetUrl) {
-        throw new Error('No links found for the tileset');
-      }
+      const tilesetUrl = getLinkUrl(
+        firstTilesetMap,
+        'self',
+        this.baseUrl,
+        undefined,
+        true
+      );
       const tilesetDoc = await fetchDocument(tilesetUrl);
-      mapTileFormats = tilesetDoc.links
-        .filter((link) => link.rel === 'item')
-        .map((link) => link.type);
+      mapTileFormats = getLinks(tilesetDoc, 'item').map((link) => link.type);
     }
 
     return {
@@ -495,7 +497,7 @@ ${e.message}`);
     return this.getCollectionDocument(collectionId)
       .then((collectionDoc) => {
         const baseUrl = this.baseUrl || '';
-        const itemLinks = getLinks(collectionDoc, 'items');
+        const itemLinks = getLinks(collectionDoc, 'items', undefined, true);
         let linkWithFormat = itemLinks.find(
           (link) => link.type === options?.outputFormat
         );
@@ -662,13 +664,10 @@ ${e.message}`);
     const stylesLink = getLinkUrl(
       doc as OgcApiDocument,
       ['styles', 'http://www.opengis.net/def/rel/ogc/1.0/styles'],
-      this.baseUrl
+      this.baseUrl,
+      undefined,
+      true
     );
-    if (!stylesLink) {
-      throw new EndpointError(
-        'Could not get styles: there is no relation of type "styles"'
-      );
-    }
     const styleData = (await fetchDocument(stylesLink)) as OgcApiStylesDocument;
     return styleData.styles.map(parseBasicStyleInfo);
   }
@@ -710,26 +709,11 @@ ${e.message}`);
     );
 
     if (stylesDoc.stylesheets) {
-      const urlFromMetadata = (
-        stylesDoc as OgcApiStyleMetadata
-      )?.stylesheets?.find(
+      return (stylesDoc as OgcApiStyleMetadata)?.stylesheets?.find(
         (s) => s.link.type === mimeType && s.link.rel === 'stylesheet'
       )?.link?.href;
-      return urlFromMetadata;
     }
 
-    const urlFromStyle = getLinkUrl(
-      stylesDoc,
-      'stylesheet',
-      this.baseUrl,
-      mimeType
-    );
-
-    if (!urlFromStyle) {
-      throw new EndpointError(
-        'Could not find stylesheet URL for given style ID and type.'
-      );
-    }
-    return urlFromStyle;
+    return getLinkUrl(stylesDoc, 'stylesheet', this.baseUrl, mimeType, true);
   }
 }

--- a/src/shared/url-utils.spec.ts
+++ b/src/shared/url-utils.spec.ts
@@ -1,4 +1,4 @@
-import { getParentPath } from './url-utils.js';
+import { getChildPath, getParentPath } from './url-utils.js';
 
 describe('link utils', () => {
   describe('getParentPath', () => {
@@ -40,6 +40,18 @@ describe('link utils', () => {
       );
       expect(getParentPath('http://example.com/foo/bar/baz?')).toBe(
         'http://example.com/foo/bar?'
+      );
+    });
+  });
+  describe('getChildPath', () => {
+    it('should append a child fragment to the path', () => {
+      expect(getChildPath('http://example.com/foo/', 'bar/')).toBe(
+        'http://example.com/foo/bar/'
+      );
+    });
+    it('should append a child fragment to the path with a slash in-between', () => {
+      expect(getChildPath('http://example.com/foo', 'bar')).toBe(
+        'http://example.com/foo/bar'
       );
     });
   });

--- a/src/shared/url-utils.ts
+++ b/src/shared/url-utils.ts
@@ -19,3 +19,16 @@ export function getParentPath(url: string): string | null {
   urlObj.pathname = pathParts.join('/');
   return urlObj.toString();
 }
+
+/**
+ * Appends a new fragment to the URL's path
+ */
+export function getChildPath(url: string, childFragment: string): string {
+  const urlObj = new URL(url, globalThis.location.toString());
+  if (urlObj.pathname.endsWith('/')) {
+    urlObj.pathname += childFragment;
+  } else {
+    urlObj.pathname += `/${childFragment}`;
+  }
+  return urlObj.toString();
+}


### PR DESCRIPTION
Fixes https://github.com/camptocamp/ogc-client/issues/111

The issue was caused by a flawed logic when creating the collection document URL.

This PR also includes better error handling in case some links which are expected to be there were not present. This should give better feedback in cases where the endpoint has quirks and specificities that are not expected by the library