### PR TITLE
refactor: move to node 20

### DIFF
--- a/app/src/Docs.vue
+++ b/app/src/Docs.vue
@@ -34,6 +34,17 @@
       </li>
     </ul>
 
+    <h2 class="mt-5 mb-4">Prerequisites</h2>
+
+    <p>
+      <LibName></LibName> requires Node.js version 20.x or newer (but we
+      recommend using
+      <a href="https://github.com/nodejs/release#release-schedule">
+        active LTS release
+      </a>
+      ).
+    </p>
+
     <h2 class="mt-5 mb-4">Usage</h2>
 
     <p>First, install <LibName></LibName> in your project:</p>

--- a/jest.node.config.cjs
+++ b/jest.node.config.cjs
@@ -9,7 +9,4 @@ module.exports = {
     ...defaultConfig.transform,
     '\\.c?js$': ['babel-jest'],
   },
-  transformIgnorePatterns: [
-    '/node_modules/(?!(node-fetch|data-uri-to-buffer|fetch-blob|formdata-polyfill)/)',
-  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.3.1-dev",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@rgrove/parse-xml": "^4.1.0",
-        "node-fetch": "^3.3.1"
+        "@rgrove/parse-xml": "^4.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.28.0",
@@ -34,12 +33,14 @@
         "ol": "^8.2.0",
         "prettier": "2.8.8",
         "proj4": "^2.10.0",
-        "regenerator-runtime": "^0.13.11",
         "ts-jest": "^29.1.1",
         "tslib": "^2.6.2",
         "typescript": "^5.3.3",
         "vite": "^5.1.0",
         "vite-plugin-dts": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "ol": ">5.x",
@@ -4488,14 +4489,6 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -5214,28 +5207,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -5306,17 +5277,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-extra": {
@@ -6984,41 +6944,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7541,12 +7466,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
     },
     "node_modules/regexpu-core": {
       "version": "6.2.0",
@@ -8951,14 +8870,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/web-worker": {
@@ -12219,11 +12130,6 @@
         }
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
-    },
     "data-urls": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -12750,15 +12656,6 @@
         "bser": "2.1.1"
       }
     },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -12813,14 +12710,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "fs-extra": {
@@ -14080,21 +13969,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -14463,12 +14337,6 @@
       "requires": {
         "regenerate": "^1.4.2"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
     },
     "regexpu-core": {
       "version": "6.2.0",
@@ -15341,11 +15209,6 @@
       "requires": {
         "makeerror": "1.0.12"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "web-worker": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "src/"
   ],
   "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
     "@rgrove/parse-xml": "^4.1.0",
     "node-fetch": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@rgrove/parse-xml": "^4.1.0",
-    "node-fetch": "^3.3.1"
+    "@rgrove/parse-xml": "^4.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",
@@ -41,7 +40,6 @@
     "ol": "^8.2.0",
     "prettier": "2.8.8",
     "proj4": "^2.10.0",
-    "regenerator-runtime": "^0.13.11",
     "ts-jest": "^29.1.1",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Typescript library for interacting with geospatial services.",
   "main": "./dist/dist-node.js",
   "browser": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "repository": "https://github.com/camptocamp/ogc-client",
   "homepage": "https://github.com/camptocamp/ogc-client",
   "files": [
@@ -14,6 +14,14 @@
   "type": "module",
   "engines": {
     "node": ">=20.0.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/dist-node.js",
+      "browser": "./dist/index.js",
+      "default": "./dist/dist-node.js"
+    }
   },
   "dependencies": {
     "@rgrove/parse-xml": "^4.1.0"

--- a/src-node/index.ts
+++ b/src-node/index.ts
@@ -1,4 +1,3 @@
-import './polyfills.js';
 import { enableFallbackWithoutWorker } from '../src/index.js';
 
 export * from '../src/index.js';

--- a/src-node/polyfills.ts
+++ b/src-node/polyfills.ts
@@ -1,5 +1,5 @@
 // mock the window.location object
-if (!('location' in global)) {
+if (!('location' in globalThis)) {
   // @ts-expect-error - location is not available on server side
-  global.location = new URL('http://localhost');
+  globalThis.location = new URL('http://localhost');
 }

--- a/src-node/polyfills.ts
+++ b/src-node/polyfills.ts
@@ -1,5 +1,0 @@
-// mock the window.location object
-if (!('location' in globalThis)) {
-  // @ts-expect-error - location is not available on server side
-  globalThis.location = new URL('http://localhost');
-}

--- a/src-node/polyfills.ts
+++ b/src-node/polyfills.ts
@@ -1,26 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-import 'regenerator-runtime/runtime';
-import { Blob } from 'buffer';
-import fetch from 'node-fetch';
-
-if (!('Blob' in global)) {
-  global.Blob = Blob;
-}
-if (!('fetch' in global)) {
-  global.fetch = fetch;
-}
-
-if (!('CustomEvent' in global)) {
-  global.CustomEvent = class {
-    constructor(type, payload) {
-      this.type = type;
-      Object.assign(this, payload);
-    }
-  };
-}
-
 // mock the window.location object
 if (!('location' in global)) {
+  // @ts-expect-error - location is not available on server side
   global.location = new URL('http://localhost');
 }

--- a/src/ogc-api/endpoint.ts
+++ b/src/ogc-api/endpoint.ts
@@ -45,7 +45,7 @@ import {
   isMimeTypeJson,
   isMimeTypeJsonFg,
 } from '../shared/mime-type.js';
-import { getChildPath } from '../shared/url-utils.js';
+import { getChildPath, getBaseUrl } from '../shared/url-utils.js';
 import { parseCollections } from './info.js';
 import EDRQueryBuilder from './edr/url_builder.js';
 
@@ -493,7 +493,7 @@ ${e.message}`);
       .then((collectionDoc) => {
         const url = new URL(
           getLinkUrl(collectionDoc, 'items', this.baseUrl),
-          globalThis.location.toString()
+          getBaseUrl()
         );
         url.pathname += `/${itemId}`;
         return url.toString();

--- a/src/ogc-api/link-utils.ts
+++ b/src/ogc-api/link-utils.ts
@@ -5,12 +5,12 @@ import {
 } from '../ogc-api/model.js';
 import { EndpointError } from '../shared/errors.js';
 import { sharedFetch } from '../shared/http-utils.js';
-import { getParentPath } from '../shared/url-utils.js';
+import { getParentPath, getBaseUrl } from '../shared/url-utils.js';
 
 export function fetchDocument<T extends OgcApiDocument>(
   url: string
 ): Promise<T> {
-  const urlObj = new URL(url, globalThis.location.toString());
+  const urlObj = new URL(url, getBaseUrl());
   urlObj.searchParams.set('f', 'json');
   return sharedFetch(urlObj.toString(), 'GET', true).then((resp) => {
     if (!resp.ok) {
@@ -119,10 +119,7 @@ export function getLinkUrl(
 ): string | null {
   const link = getLinks(doc, relType, mimeType, assertPresence)[0];
   if (!link) return null;
-  return new URL(
-    link.href,
-    baseUrl || globalThis.location.toString()
-  ).toString();
+  return new URL(link.href, getBaseUrl(baseUrl)).toString();
 }
 
 export async function fetchLink(

--- a/src/shared/url-utils.spec.ts
+++ b/src/shared/url-utils.spec.ts
@@ -1,6 +1,14 @@
-import { getChildPath, getParentPath } from './url-utils.js';
+import { getChildPath, getParentPath, getBaseUrl } from './url-utils.js';
 
 describe('link utils', () => {
+  describe('getBaseUrl', () => {
+    it('should return the base url', () => {
+      expect(getBaseUrl().toString()).toBe('http://localhost/');
+      expect(getBaseUrl('http://example.com').toString()).toBe(
+        'http://example.com/'
+      );
+    });
+  });
   describe('getParentPath', () => {
     it('should return null if no parent path', () => {
       expect(getParentPath('http://example.com')).toBeNull();

--- a/src/shared/url-utils.ts
+++ b/src/shared/url-utils.ts
@@ -1,8 +1,26 @@
 /**
+ * Returns the base url of the given url
+ *
+ * @param url - the url to get the base url from
+ * @returns the base url
+ */
+export function getBaseUrl(url?: string): string | URL {
+  if (url && typeof url === 'string') {
+    return new URL(url);
+  }
+
+  if ('location' in globalThis && typeof globalThis.location === 'object') {
+    return globalThis.location.toString();
+  }
+
+  return new URL('http://localhost');
+}
+
+/**
  * Returns the parent path from a URL based on a version pattern (x.y.z).
  */
 export function getParentPath(url: string): string | null {
-  const urlObj = new URL(url, globalThis.location.toString());
+  const urlObj = new URL(url, getBaseUrl());
   let pathParts = urlObj.pathname.split('/');
   if (pathParts.length <= 2) {
     // cannot go further up
@@ -24,7 +42,7 @@ export function getParentPath(url: string): string | null {
  * Appends a new fragment to the URL's path
  */
 export function getChildPath(url: string, childFragment: string): string {
-  const urlObj = new URL(url, globalThis.location.toString());
+  const urlObj = new URL(url, getBaseUrl());
   if (urlObj.pathname.endsWith('/')) {
     urlObj.pathname += childFragment;
   } else {

--- a/src/tms/link-utils.ts
+++ b/src/tms/link-utils.ts
@@ -3,7 +3,7 @@ import { parseTileMapServiceXML, parseTileMapXML } from './parser.js';
 import { TileMapInfo, TileMapService } from './model.js';
 import { XmlDocument } from '@rgrove/parse-xml';
 import { getRootElement, parseXmlString } from '../shared/xml-utils.js';
-import { getParentPath } from '../shared/url-utils.js';
+import { getParentPath, getBaseUrl } from '../shared/url-utils.js';
 
 const MAX_DEPTH = 3;
 
@@ -11,7 +11,7 @@ const MAX_DEPTH = 3;
  * Fetches the XML string from a URL.
  */
 export async function fetchXml(url: string): Promise<XmlDocument> {
-  const urlObj = new URL(url, globalThis.location.toString());
+  const urlObj = new URL(url, getBaseUrl());
   const resp = await sharedFetch(urlObj.toString(), 'GET', true);
   if (!resp.ok) {
     throw new Error(`The document at ${urlObj} could not be fetched.`);
@@ -79,7 +79,7 @@ export async function fetchTileMapResourceXML(
  */
 export function normalizeUrl(url: string): string {
   try {
-    const urlObj = new URL(url, globalThis.location.toString());
+    const urlObj = new URL(url, getBaseUrl());
     if (!urlObj.pathname.endsWith('/')) {
       urlObj.pathname += '/';
     }

--- a/test-setup.node.ts
+++ b/test-setup.node.ts
@@ -1,6 +1,3 @@
-// first apply the node polyfills & specificities
-import './src-node/polyfills.js';
-
 // then run the test environment setup
 import './test-setup.ts';
 

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -47,7 +47,7 @@ globalThis.caches = {
 // mock Worker class to work synchronously
 // requires an absolute file path
 // this is mainly ripped off of https://github.com/developit/jsdom-worker
-global.Worker = function Worker(filePath) {
+globalThis.Worker = function Worker(filePath) {
   let getScopeVar;
   let messageQueue = [];
   const inside = mitt();
@@ -112,9 +112,9 @@ global.Worker = function Worker(filePath) {
     });
 
   // mock global scope
-  global.WorkerGlobalScope = scope;
+  globalThis.WorkerGlobalScope = scope;
 };
 
-// global.TextDecoder = StringDecoder
-// global.TextDecoder.prototype.decode = StringDecoder.prototype.write
-global.TextDecoder = TextDecoder;
+// globalThis.TextDecoder = StringDecoder
+// globalThis.TextDecoder.prototype.decode = StringDecoder.prototype.write
+globalThis.TextDecoder = TextDecoder;

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import 'regenerator-runtime/runtime';
 import mitt from 'mitt';
 import { TextDecoder } from 'util';
 import CacheMock from 'browser-cache-mock';
@@ -32,9 +31,6 @@ globalThis.mockFetch = jest.fn().mockImplementation(async (url, options) => {
     status: 200,
     ok: true,
     headers: { get: () => null },
-    clone: function () {
-      return this;
-    },
   };
 });
 globalThis.fetch = globalThis.mockFetch;

--- a/vite.node-config.js
+++ b/vite.node-config.js
@@ -5,7 +5,7 @@ export default defineConfig({
   build: {
     ssr: true,
     rollupOptions: {
-      external: [/^ol/, 'proj4', 'node-fetch'],
+      external: [/^ol/, 'proj4'],
       input: 'src-node/index.ts',
       output: {
         entryFileNames: 'dist-node.js',


### PR DESCRIPTION
This PR attempts to change:

- Explicitly states supported node version (`20+`) in `package.json` and `docs`
- Drops 3rd party polyfills and use runtime bultins, namely `fetch`, `Blob`  and `async/await`
- Removes monkey patching on globals, namely `CustomEvent` and `location`
- Adds `exports` in `package.json` 

Fixes: #121 