### PR TITLE
feature: Better exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,56 @@
       "import": "./dist/dist-node.js",
       "browser": "./dist/index.js",
       "default": "./dist/dist-node.js"
+    },
+    "./shared/cache": {
+      "types": "./dist/api/shared/cache.d.ts",
+      "import": "./dist/api/shared/cache.js",
+      "default": "./dist/api/shared/cache.js"
+    },
+    "./shared/errors": {
+      "types": "./dist/api/shared/errors.d.ts",
+      "import": "./dist/api/shared/errors.js",
+      "default": "./dist/api/shared/errors.js"
+    },
+    "./shared/http-utils": {
+      "types": "./dist/api/shared/http-utils.d.ts",
+      "import": "./dist/api/shared/http-utils.js",
+      "default": "./dist/api/shared/http-utils.js"
+    },
+    "./shared/models": {
+      "types": "./dist/api/shared/models.d.ts",
+      "import": "./dist/api/shared/models.js",
+      "default": "./dist/api/shared/models.js"
+    },
+    "./ogc-api": {
+      "types": "./dist/api/ogc-api.d.ts",
+      "import": "./dist/api/ogc-api.js",
+      "default": "./dist/api/ogc-api.js"
+    },
+    "./tms": {
+      "types": "./dist/api/tms.d.ts",
+      "import": "./dist/api/tms.js",
+      "default": "./dist/api/tms.js"
+    },
+    "./wfs": {
+      "types": "./dist/api/wfs.d.ts",
+      "import": "./dist/api/wfs.js",
+      "default": "./dist/api/wfs.js"
+    },
+    "./wms": {
+      "types": "./dist/api/wms.d.ts",
+      "import": "./dist/api/wms.js",
+      "default": "./dist/api/wms.js"
+    },
+    "./wmts": {
+      "types": "./dist/api/wmts.d.ts",
+      "import": "./dist/api/wmts.js",
+      "default": "./dist/api/wmts.js"
+    },
+    "./worker": {
+      "types": "./dist/api/worker.d.ts",
+      "import": "./dist/api/worker.js",
+      "default": "./dist/api/worker.js"
     }
   },
   "dependencies": {

--- a/src/api/ogc-api.ts
+++ b/src/api/ogc-api.ts
@@ -1,0 +1,26 @@
+export { default as OgcApiEndpoint } from '../ogc-api/endpoint.js';
+export { DataQueryTypes, CollectionParameterTypes } from '../ogc-api/model.js';
+export type {
+  ConformanceClass,
+  OgcApiEndpointInfo,
+  DataQueryType,
+  CollectionParameterType,
+  CollectionParameter,
+  EdrParameterInfo,
+  OgcApiCollectionInfo,
+  OgcApiDocumentLink,
+  OgcApiDocument,
+  OgcApiRecordContact,
+  OgcApiRecordLanguage,
+  OgcApiRecordProperties,
+  OgcApiRecord,
+  OgcApiCollectionItem,
+  TileMatrixSet,
+  StyleItem,
+  OgcStyleFull,
+  OgcStyleBrief,
+  OgcApiStylesDocument,
+  OgcApiStyleRecord,
+  OgcApiStylesheet,
+  OgcApiStyleMetadata,
+} from '../ogc-api/model.js';

--- a/src/api/shared/cache.ts
+++ b/src/api/shared/cache.ts
@@ -1,0 +1,1 @@
+export { useCache, clearCache } from '../../shared/cache.js';

--- a/src/api/shared/errors.ts
+++ b/src/api/shared/errors.ts
@@ -1,0 +1,5 @@
+export {
+  check,
+  ServiceExceptionError,
+  EndpointError,
+} from '../../shared/errors.js';

--- a/src/api/shared/http-utils.ts
+++ b/src/api/shared/http-utils.ts
@@ -1,5 +1,6 @@
 export {
   sharedFetch,
   setFetchOptions,
+  setQueryParams,
   resetFetchOptions,
 } from '../../shared/http-utils.js';

--- a/src/api/shared/http-utils.ts
+++ b/src/api/shared/http-utils.ts
@@ -1,0 +1,5 @@
+export {
+  sharedFetch,
+  setFetchOptions,
+  resetFetchOptions,
+} from '../../shared/http-utils.js';

--- a/src/api/shared/models.ts
+++ b/src/api/shared/models.ts
@@ -1,0 +1,12 @@
+export type {
+  Address,
+  Contact,
+  Provider,
+  LayerStyle,
+  BoundingBox,
+  MetadataURL,
+  FetchOptions,
+  GenericEndpointInfo,
+  MimeType,
+  CrsCode,
+} from '../../shared/models.js';

--- a/src/api/tms.ts
+++ b/src/api/tms.ts
@@ -1,0 +1,14 @@
+export { default as TmsEndpoint } from '../tms/endpoint.js';
+export type {
+  TileMapService,
+  TmsEndpointInfo,
+  TileMapInfo,
+  ContactInformation,
+  Metadata,
+  Attribution,
+  TileMapReference,
+  TileSet,
+  TileFormat,
+  Origin,
+  TmsProfile,
+} from '../tms/model.js';

--- a/src/api/wfs.ts
+++ b/src/api/wfs.ts
@@ -1,0 +1,14 @@
+export { default as WfsEndpoint } from '../wfs/endpoint.js';
+export type {
+  WfsVersion,
+  WfsFeatureWithProps,
+  WfsFeatureTypeSummary,
+  WfsFeatureTypeBrief,
+  FeatureGeometryType,
+  FeaturePropertyType,
+  WfsFeatureTypeFull,
+  WfsFeatureTypePropDetails,
+  WfsFeatureTypePropsDetails,
+  WfsFeatureTypeUniqueValue,
+  WfsGetFeatureOptions,
+} from '../wfs/model.js';

--- a/src/api/wms.ts
+++ b/src/api/wms.ts
@@ -1,0 +1,7 @@
+export { default as WmsEndpoint } from '../wms/endpoint.js';
+export type {
+  WmsLayerFull,
+  WmsVersion,
+  WmsLayerSummary,
+  WmsLayerAttribution,
+} from '../wms/model.js';

--- a/src/api/wmts.ts
+++ b/src/api/wmts.ts
@@ -1,0 +1,8 @@
+export { default as WmtsEndpoint } from '../wmts/endpoint.js';
+export type {
+  WmtsLayerDimensionValue,
+  WmtsLayerResourceLink,
+  WmtsEndpointInfo,
+  WmtsLayer,
+  WmtsMatrixSet,
+} from '../wmts/model.js';

--- a/src/api/worker.ts
+++ b/src/api/worker.ts
@@ -1,0 +1,2 @@
+export { enableFallbackWithoutWorker } from '../worker/index.js';
+import '../worker-fallback/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,60 +1,12 @@
-export { default as WfsEndpoint } from './wfs/endpoint.js';
-export type {
-  WfsVersion,
-  WfsFeatureWithProps,
-  WfsFeatureTypeSummary,
-  WfsFeatureTypeBrief,
-  FeatureGeometryType,
-  FeaturePropertyType,
-  WfsFeatureTypeFull,
-  WfsFeatureTypePropDetails,
-  WfsFeatureTypePropsDetails,
-  WfsFeatureTypeUniqueValue,
-  WfsGetFeatureOptions,
-} from './wfs/model.js';
-export { default as WmsEndpoint } from './wms/endpoint.js';
-export type {
-  WmsLayerFull,
-  WmsVersion,
-  WmsLayerSummary,
-  WmsLayerAttribution,
-} from './wms/model.js';
-export { default as WmtsEndpoint } from './wmts/endpoint.js';
-export type {
-  WmtsLayerDimensionValue,
-  WmtsLayerResourceLink,
-  WmtsEndpointInfo,
-  WmtsLayer,
-  WmtsMatrixSet,
-} from './wmts/model.js';
-export type {
-  Address,
-  Contact,
-  Provider,
-  LayerStyle,
-  BoundingBox,
-  MetadataURL,
-  FetchOptions,
-  GenericEndpointInfo,
-  MimeType,
-  CrsCode,
-} from './shared/models.js';
-export { default as OgcApiEndpoint } from './ogc-api/endpoint.js';
-export * from './ogc-api/model.js';
-export { default as TmsEndpoint } from './tms/endpoint.js';
-export * from './tms/model.js';
+export * from './api/ogc-api.js';
+export * from './api/tms.js';
+export * from './api/wfs.js';
+export * from './api/wms.js';
+export * from './api/wmts.js';
 
-export { useCache, clearCache } from './shared/cache.js';
-export {
-  sharedFetch,
-  setFetchOptions,
-  resetFetchOptions,
-} from './shared/http-utils.js';
-export {
-  check,
-  ServiceExceptionError,
-  EndpointError,
-} from './shared/errors.js';
+export * from './api/shared/cache.js';
+export * from './api/shared/errors.js';
+export * from './api/shared/http-utils.js';
+export type * from './api/shared/models.js';
 
-export { enableFallbackWithoutWorker } from './worker/index.js';
-import './worker-fallback/index.js';
+export * from './api/worker.js';


### PR DESCRIPTION
This has the aim of exposing the existing API without using a single barrel file, so that e.g. the http-utils functions can be sensibly used by other packages or so that a bundler-friendly import of individual modules can be used.

The existing exports as defined in the base index.js have been modularised into indidual files under api/. Everything is still re-exported in index.js ensuring the existing exported API is still available without change, but adding the new individual exports to be used for those who want them.

As a bonus the function `setQueryParams()` from `http-utils` is exposed as this could be helpful for users of this library. Actually this was the reason I started on this PR, the rest was just trying to do things better :)