### PR TITLE
[WMTS]: parse crs short name from URN or URL

### DIFF
--- a/src/wmts/capabilities.spec.ts
+++ b/src/wmts/capabilities.spec.ts
@@ -148,7 +148,7 @@ describe('WMTS Capabilities', () => {
             boundingBox: [
               1799448.394855, 6124949.74777, 1848250.442089, 6162571.828177,
             ],
-            crs: 'urn:ogc:def:crs:EPSG:6.18:3:3857',
+            crs: 'EPSG:3857',
             identifier: 'google3857',
             tileMatrices: [
               {
@@ -335,7 +335,7 @@ describe('WMTS Capabilities', () => {
             wellKnownScaleSet: 'urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible',
           },
           {
-            crs: 'urn:ogc:def:crs:OGC:1.3:CRS84',
+            crs: 'OGC:CRS84',
             identifier: 'BigWorldPixel',
             tileMatrices: [
               {
@@ -396,7 +396,7 @@ describe('WMTS Capabilities', () => {
             wellKnownScaleSet: 'urn:ogc:def:wkss:OGC:1.0:GlobalCRS84Pixel',
           },
           {
-            crs: 'urn:ogc:def:crs:OGC:1.3:CRS84',
+            crs: 'OGC:CRS84',
             identifier: 'BigWorld',
             tileMatrices: [
               {
@@ -420,7 +420,7 @@ describe('WMTS Capabilities', () => {
             ],
           },
           {
-            crs: 'urn:ogc:def:crs:EPSG:6.18:3:3857',
+            crs: 'EPSG:3857',
             identifier: 'google3857subset',
             tileMatrices: [
               {
@@ -451,7 +451,7 @@ describe('WMTS Capabilities', () => {
         const doc = parseXmlString(arcgis);
         expect(readMatrixSetsFromCapabilities(doc)).toEqual([
           {
-            crs: 'urn:ogc:def:crs:EPSG::3857',
+            crs: 'EPSG:3857',
             identifier: 'default028mm',
             tileMatrices: expect.arrayContaining([
               {
@@ -484,7 +484,7 @@ describe('WMTS Capabilities', () => {
             ]),
           },
           {
-            crs: 'urn:ogc:def:crs:EPSG:6.18.3:3857',
+            crs: 'EPSG:3857',
             identifier: 'GoogleMapsCompatible',
             wellKnownScaleSet: 'urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible',
             tileMatrices: expect.arrayContaining([
@@ -614,17 +614,17 @@ describe('WMTS Capabilities', () => {
             matrixSets: [
               {
                 identifier: 'BigWorldPixel',
-                crs: 'urn:ogc:def:crs:OGC:1.3:CRS84',
+                crs: 'OGC:CRS84',
                 limits: [],
               },
               {
                 identifier: 'google3857',
-                crs: 'urn:ogc:def:crs:EPSG:6.18:3:3857',
+                crs: 'EPSG:3857',
                 limits: [],
               },
               {
                 identifier: 'google3857subset',
-                crs: 'urn:ogc:def:crs:EPSG:6.18:3:3857',
+                crs: 'EPSG:3857',
                 limits: [],
               },
             ],
@@ -676,12 +676,12 @@ describe('WMTS Capabilities', () => {
             matrixSets: [
               {
                 identifier: 'default028mm',
-                crs: 'urn:ogc:def:crs:EPSG::3857',
+                crs: 'EPSG:3857',
                 limits: [],
               },
               {
                 identifier: 'GoogleMapsCompatible',
-                crs: 'urn:ogc:def:crs:EPSG:6.18.3:3857',
+                crs: 'EPSG:3857',
                 limits: [],
               },
             ],

--- a/src/wmts/capabilities.spec.ts
+++ b/src/wmts/capabilities.spec.ts
@@ -335,7 +335,7 @@ describe('WMTS Capabilities', () => {
             wellKnownScaleSet: 'urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible',
           },
           {
-            crs: 'OGC:CRS84',
+            crs: 'urn:ogc:def:crs:OGC:1.3:CRS84',
             identifier: 'BigWorldPixel',
             tileMatrices: [
               {
@@ -396,7 +396,7 @@ describe('WMTS Capabilities', () => {
             wellKnownScaleSet: 'urn:ogc:def:wkss:OGC:1.0:GlobalCRS84Pixel',
           },
           {
-            crs: 'OGC:CRS84',
+            crs: 'urn:ogc:def:crs:OGC:1.3:CRS84',
             identifier: 'BigWorld',
             tileMatrices: [
               {
@@ -614,7 +614,7 @@ describe('WMTS Capabilities', () => {
             matrixSets: [
               {
                 identifier: 'BigWorldPixel',
-                crs: 'OGC:CRS84',
+                crs: 'urn:ogc:def:crs:OGC:1.3:CRS84',
                 limits: [],
               },
               {

--- a/src/wmts/capabilities.ts
+++ b/src/wmts/capabilities.ts
@@ -27,6 +27,28 @@ function parseBBox(xmlElement: XmlElement): BoundingBox {
   return result;
 }
 
+/**
+ * Parse a URN/URL CRS string into a short name format
+ * @param crsString - URN/URL CRS string (e.g. "urn:ogc:def:crs:EPSG::4326" or "http://www.opengis.net/def/crs/EPSG/0/4326")
+ * @returns The parsed CRS string in short name format (e.g. "EPSG:4326")
+ */
+function parseCRS(crsString: string): string {
+  if (!crsString) return '';
+  const segments = crsString.trim().split(/[/:]+/).filter(Boolean);
+  if (segments.length === 0) return crsString;
+  const code = segments.pop() || '';
+  let authority = null;
+  const knownAuthorities = ['EPSG', 'ESRI', 'IAU', 'IGNF', 'NKG', 'OGC'];
+  while (segments.length > 0) {
+    const candidate = segments.pop() || '';
+    if (knownAuthorities.includes(candidate.toUpperCase())) {
+      authority = candidate.toUpperCase();
+      break;
+    }
+  }
+  return authority ? `${authority}:${code}` : code;
+}
+
 export function readInfoFromCapabilities(
   capabilitiesDoc: XmlDocument
 ): WmtsEndpointInfo {
@@ -104,7 +126,7 @@ export function readMatrixSetsFromCapabilities(
     const boundingBox = parseBBox(findChildElement(element, 'BoundingBox'));
     return {
       identifier: getElementText(findChildElement(element, 'Identifier')),
-      crs: getElementText(findChildElement(element, 'SupportedCRS')),
+      crs: parseCRS(getElementText(findChildElement(element, 'SupportedCRS'))),
       tileMatrices: findChildrenElement(element, 'TileMatrix').map(
         parseMatrixSet
       ),
@@ -124,7 +146,7 @@ export function readLayersFromCapabilities(
    * Get the TileMatrixSet CRS
    * @param contentsEl - Contents
    * @param identifier - TileMatrixSet identifier
-   * @returns The SupportedCRS of the TileMatrixSet
+   * @returns The parsed supported CRS of the TileMatrixSet
    */
   function getMatrixSetCrs(contentsEl: XmlElement, identifier: string): string {
     const matrixSet = findChildrenElement(contentsEl, 'TileMatrixSet').find(
@@ -133,7 +155,8 @@ export function readLayersFromCapabilities(
         return getElementText(identifierEl) === identifier;
       }
     );
-    return getElementText(findChildElement(matrixSet, 'SupportedCRS'));
+    const supportedCrsEl = findChildElement(matrixSet, 'SupportedCRS');
+    return parseCRS(getElementText(supportedCrsEl));
   }
 
   /**

--- a/src/wmts/capabilities.ts
+++ b/src/wmts/capabilities.ts
@@ -8,14 +8,15 @@ import {
   getRootElement,
 } from '../shared/xml-utils.js';
 import type {
-  WmtsLayerResourceLink,
   MatrixSetLink,
   TileMatrix,
   WmtsEndpointInfo,
   WmtsLayer,
+  WmtsLayerResourceLink,
   WmtsMatrixSet,
 } from './model.js';
 import type { XmlDocument, XmlElement } from '@rgrove/parse-xml';
+import { simplifyEpsgUrn } from '../shared/crs-utils.js';
 
 function parseBBox(xmlElement: XmlElement): BoundingBox {
   const result = ['LowerCorner', 'UpperCorner']
@@ -25,28 +26,6 @@ function parseBBox(xmlElement: XmlElement): BoundingBox {
     .map(parseFloat) as BoundingBox;
   if (result.some(Number.isNaN)) return null;
   return result;
-}
-
-/**
- * Parse a URN/URL CRS string into a short name format
- * @param crsString - URN/URL CRS string (e.g. "urn:ogc:def:crs:EPSG::4326" or "http://www.opengis.net/def/crs/EPSG/0/4326")
- * @returns The parsed CRS string in short name format (e.g. "EPSG:4326")
- */
-function parseCRS(crsString: string): string {
-  if (!crsString) return '';
-  const segments = crsString.trim().split(/[/:]+/).filter(Boolean);
-  if (segments.length === 0) return crsString;
-  const code = segments.pop() || '';
-  let authority = null;
-  const knownAuthorities = ['EPSG', 'ESRI', 'IAU', 'IGNF', 'NKG', 'OGC'];
-  while (segments.length > 0) {
-    const candidate = segments.pop() || '';
-    if (knownAuthorities.includes(candidate.toUpperCase())) {
-      authority = candidate.toUpperCase();
-      break;
-    }
-  }
-  return authority ? `${authority}:${code}` : code;
 }
 
 export function readInfoFromCapabilities(
@@ -126,7 +105,9 @@ export function readMatrixSetsFromCapabilities(
     const boundingBox = parseBBox(findChildElement(element, 'BoundingBox'));
     return {
       identifier: getElementText(findChildElement(element, 'Identifier')),
-      crs: parseCRS(getElementText(findChildElement(element, 'SupportedCRS'))),
+      crs: simplifyEpsgUrn(
+        getElementText(findChildElement(element, 'SupportedCRS'))
+      ),
       tileMatrices: findChildrenElement(element, 'TileMatrix').map(
         parseMatrixSet
       ),
@@ -155,8 +136,9 @@ export function readLayersFromCapabilities(
         return getElementText(identifierEl) === identifier;
       }
     );
-    const supportedCrsEl = findChildElement(matrixSet, 'SupportedCRS');
-    return parseCRS(getElementText(supportedCrsEl));
+    return simplifyEpsgUrn(
+      getElementText(findChildElement(matrixSet, 'SupportedCRS'))
+    );
   }
 
   /**

--- a/src/wmts/endpoint.spec.ts
+++ b/src/wmts/endpoint.spec.ts
@@ -151,7 +151,7 @@ describe('WmtsEndpoint', () => {
         );
         expect(buildOpenLayersTileGrid).toHaveBeenCalledWith(
           {
-            crs: 'urn:ogc:def:crs:OGC:1.3:CRS84',
+            crs: 'OGC:CRS84',
             identifier: 'BigWorldPixel',
             tileMatrices: expect.arrayContaining([
               {
@@ -181,7 +181,7 @@ describe('WmtsEndpoint', () => {
             boundingBox: [
               1799448.394855, 6124949.74777, 1848250.442089, 6162571.828177,
             ],
-            crs: 'urn:ogc:def:crs:EPSG:6.18:3:3857',
+            crs: 'EPSG:3857',
             identifier: 'google3857',
             tileMatrices: expect.arrayContaining([
               {

--- a/src/wmts/endpoint.spec.ts
+++ b/src/wmts/endpoint.spec.ts
@@ -151,7 +151,7 @@ describe('WmtsEndpoint', () => {
         );
         expect(buildOpenLayersTileGrid).toHaveBeenCalledWith(
           {
-            crs: 'OGC:CRS84',
+            crs: 'urn:ogc:def:crs:OGC:1.3:CRS84',
             identifier: 'BigWorldPixel',
             tileMatrices: expect.arrayContaining([
               {


### PR DESCRIPTION
The CRS read from SupportedCRS should be as flexible as possible for downstream libs, and so we parse only the short name format.