### PR TITLE
Last API adjustments before v2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,11 +95,8 @@ export {
   setFetchOptions,
   resetFetchOptions,
 } from './shared/http-utils.js';
-export {
-  check,
-  ServiceExceptionError,
-  EndpointError,
-} from './shared/errors.js';
+export { setQueryParams } from './shared/url-utils.js';
+export { ServiceExceptionError, EndpointError } from './shared/errors.js';
 
 export { enableFallbackWithoutWorker } from './worker/index.js';
 import './worker-fallback/index.js';

--- a/src/ogc-api/model.ts
+++ b/src/ogc-api/model.ts
@@ -1,4 +1,4 @@
-import { Geometry } from 'geojson';
+import type { Geometry } from 'geojson';
 import {
   BoundingBox,
   CrsCode,

--- a/src/shared/url-utils.ts
+++ b/src/shared/url-utils.ts
@@ -58,6 +58,7 @@ export function getChildPath(url: string, childFragment: string): string {
  * proxy, which is an aberration and should be forbidden btw), then the encoded URL
  * will be modified instead.
  * Params set to `null` will be removed.
+ * @private do not make this part of the API doc, but we still allow its use because it's a nice utility!
  */
 export function setQueryParams(
   url: string,

--- a/src/stac/model.ts
+++ b/src/stac/model.ts
@@ -1,4 +1,4 @@
-import { Feature, Geometry } from 'geojson';
+import type { Feature, Geometry } from 'geojson';
 
 /**
  * STAC specification version 1.0.0


### PR DESCRIPTION
Followed the recommandation in https://github.com/camptocamp/ogc-client/pull/126 to make `setQueryParams` available, even though it's not part of the API reference.

Removed the `check()` function which didn't belong in the public API.

Marked some imports as `types` only for clarity.

@ejn if you're still around, I didn't add separate import paths for the various parts of the library, I did some testing and tree shaking works OK with the current way the lib is built.There is always a flat cost when importing the library, even when doing nothing; this is because of all the side-effects related to the worker (registering tasks etc.). I might get around to optimize this and maybe initialize the worker lazily or something. For now the API will stay the same for the upcoming v2. Thanks!