### PR TITLE
Fix name of elements that contains dimension values

### DIFF
--- a/src/wmts/capabilities.spec.ts
+++ b/src/wmts/capabilities.spec.ts
@@ -649,7 +649,7 @@ describe('WMTS Capabilities', () => {
               {
                 defaultValue: '20110805',
                 identifier: 'Time',
-                values: [],
+                values: ['20110805', '20081024'],
               },
               {
                 defaultValue: 'abcd',

--- a/src/wmts/capabilities.ts
+++ b/src/wmts/capabilities.ts
@@ -246,7 +246,7 @@ export function readLayersFromCapabilities(
         const defaultValue = getElementText(
           findChildElement(element, 'Default'),
         );
-        const values = findChildrenElement(element, 'Values').map(
+        const values = findChildrenElement(element, 'Value').map(
           getElementText,
         );
         return { identifier, defaultValue, values };

--- a/src/wmts/endpoint.spec.ts
+++ b/src/wmts/endpoint.spec.ts
@@ -88,7 +88,7 @@ describe('WmtsEndpoint', () => {
             {
               defaultValue: '20110805',
               identifier: 'Time',
-              values: [],
+              values: ['20110805', '20081024'],
             },
             {
               defaultValue: 'abcd',


### PR DESCRIPTION
The element name is `Value`, not `Values`.
See https://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd

This commit fixes the element name in the implementation and adapts tests, which were previously missing parsed values.

Discovered while trying to parse the following WMTS capabilities doc: https://wmts.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml

Example `Dimension` element with values contained in the doc linked above:
```
<Dimension>
  <ows:Identifier>Time</ows:Identifier>
  <Default>current</Default>
  <Value>current</Value>
  <Value>2025</Value>
  <Value>2024</Value>
  <Value>2023</Value>
  <Value>2022</Value>
  <Value>2021</Value>
  <Value>2020</Value>
  <Value>2019</Value>
  <Value>2010</Value>
  <Value>2000</Value>
  <Value>1990</Value>
  <Value>1980</Value>
  <Value>1970</Value>
  <Value>1960</Value>
  <Value>1945</Value>
  <Value>1919</Value>
</Dimension>
```